### PR TITLE
chore: update mdctl to v0.0.7

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.5"
+  version "0.0.7"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "faf5f8ff8851e369370291e35715ae7f2950b95c77349dc61a8295123680501f"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "beedfb35d77e2f38f1392cab594db0603897b4668edb7f39b2a3d84683b75323"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "ed6b4b1067f1731de052b20cae6facd56eab2048ef955fab7b418488607d55ac"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "703dfa2f7f0a68bd2095b56264672eaad3c226e84b8d1bc934590f3a2a811b9c"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): beedfb35d77e2f38f1392cab594db0603897b4668edb7f39b2a3d84683b75323\n- Darwin(arm64): faf5f8ff8851e369370291e35715ae7f2950b95c77349dc61a8295123680501f