### PR TITLE
chore: update mdctl to v0.0.8

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.7"
+  version "0.0.8"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "faf5f8ff8851e369370291e35715ae7f2950b95c77349dc61a8295123680501f"
+      sha256 "0caca892099bbf345c0d9e10beeea45c00cd54e916f10bcfe52954f84342365c"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "beedfb35d77e2f38f1392cab594db0603897b4668edb7f39b2a3d84683b75323"
+      sha256 "728b4846630693f009ebe49cf179a1ae59aafa5718c7ee4b4877ae0a9ed8c748"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "ed6b4b1067f1731de052b20cae6facd56eab2048ef955fab7b418488607d55ac"
+      sha256 "4a5abcfe768a332a5a25a5747a558c90b071a8304ab3359f002915d2986765e5"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "703dfa2f7f0a68bd2095b56264672eaad3c226e84b8d1bc934590f3a2a811b9c"
+      sha256 "6f04559dcc3561461865b2bcf8f84a3173919412fe8d91cb98ab5966e8219de8"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 728b4846630693f009ebe49cf179a1ae59aafa5718c7ee4b4877ae0a9ed8c748\n- Darwin(arm64): 0caca892099bbf345c0d9e10beeea45c00cd54e916f10bcfe52954f84342365c