### PR TITLE
chore: update mdctl to v0.0.9

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.8"
+  version "0.0.9"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "0caca892099bbf345c0d9e10beeea45c00cd54e916f10bcfe52954f84342365c"
+      sha256 "1b962f9a10c47831e41369da9e5312e5ade6ac019d239bc2b45f10d8a8b612ac"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "728b4846630693f009ebe49cf179a1ae59aafa5718c7ee4b4877ae0a9ed8c748"
+      sha256 "168e6f4d629a843c077f13fcba0bd42c5dced9ececb14342b55dcbccf8bee0a3"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "4a5abcfe768a332a5a25a5747a558c90b071a8304ab3359f002915d2986765e5"
+      sha256 "25cae07b8268596ac24ed5dd756b76f899f3c5d8cb67301dedb530be61f908a5"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "6f04559dcc3561461865b2bcf8f84a3173919412fe8d91cb98ab5966e8219de8"
+      sha256 "4268f46c0f0d6bb477a74995a606d775e571ee8d0b672514121a24cc07ee180e"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 168e6f4d629a843c077f13fcba0bd42c5dced9ececb14342b55dcbccf8bee0a3\n- Darwin(arm64): 1b962f9a10c47831e41369da9e5312e5ade6ac019d239bc2b45f10d8a8b612ac