### PR TITLE
chore: update mdctl to v0.0.10

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.9"
+  version "0.0.10"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "1b962f9a10c47831e41369da9e5312e5ade6ac019d239bc2b45f10d8a8b612ac"
+      sha256 "6456e5cc03a085c5072fcae5f38ba42850239da9e23aeb642cc8cb742e1d7386"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "168e6f4d629a843c077f13fcba0bd42c5dced9ececb14342b55dcbccf8bee0a3"
+      sha256 "b8ef549f85f923efd4320f6e3c7050ce6a04d9601428d6369e7d7df1080de959"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "25cae07b8268596ac24ed5dd756b76f899f3c5d8cb67301dedb530be61f908a5"
+      sha256 "110b685322ca73cba004b6be5731925ef236542734909cc1d12c941d9b496ccc"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "4268f46c0f0d6bb477a74995a606d775e571ee8d0b672514121a24cc07ee180e"
+      sha256 "ddbf0e2507360bd2e35d8a1cbf7ee275fa22397dbce27031b73ab3d0e6b9e721"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): b8ef549f85f923efd4320f6e3c7050ce6a04d9601428d6369e7d7df1080de959\n- Darwin(arm64): 6456e5cc03a085c5072fcae5f38ba42850239da9e23aeb642cc8cb742e1d7386