### PR TITLE
chore: update mdctl to v0.0.11

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.10"
+  version "0.0.11"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "6456e5cc03a085c5072fcae5f38ba42850239da9e23aeb642cc8cb742e1d7386"
+      sha256 "87d27ed8c90c00bf53f3fb2b43d4de48f798b21224529db4e498c93c7ea710c1"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "b8ef549f85f923efd4320f6e3c7050ce6a04d9601428d6369e7d7df1080de959"
+      sha256 "41b95fccd7e3770a9f8b9d8b636fcf37f357a74d3521cf88efcaa5cdc9c5d57a"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "110b685322ca73cba004b6be5731925ef236542734909cc1d12c941d9b496ccc"
+      sha256 "c709ca5e1e4cbf48c8f70aa4ed1ebbe7687aeda13431f04f174f775742ddae4d"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "ddbf0e2507360bd2e35d8a1cbf7ee275fa22397dbce27031b73ab3d0e6b9e721"
+      sha256 "d30d4727eb24dcf95dbc0d903c20e52382641d9731904fdd4c123ef03c33573d"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 41b95fccd7e3770a9f8b9d8b636fcf37f357a74d3521cf88efcaa5cdc9c5d57a\n- Darwin(arm64): 87d27ed8c90c00bf53f3fb2b43d4de48f798b21224529db4e498c93c7ea710c1