### PR TITLE
chore: update mdctl to v0.1.0

### DIFF
--- a/Formula/mdctl.rb
+++ b/Formula/mdctl.rb
@@ -1,25 +1,25 @@
 class Mdctl < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/mdctl"
-  version "0.0.11"
+  version "0.1.0"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_arm64.tar.gz"
-      sha256 "87d27ed8c90c00bf53f3fb2b43d4de48f798b21224529db4e498c93c7ea710c1"
+      sha256 "231064dce55a6de51c41b6254a43f07762f44532cbb020ab808b4ae38ed931eb"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Darwin_x86_64.tar.gz"
-      sha256 "41b95fccd7e3770a9f8b9d8b636fcf37f357a74d3521cf88efcaa5cdc9c5d57a"
+      sha256 "29da5846e97fe28592dbc9f909304ef912905e489098e68c4f332ef1cd3cd4c4"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_arm64.tar.gz"
-      sha256 "c709ca5e1e4cbf48c8f70aa4ed1ebbe7687aeda13431f04f174f775742ddae4d"
+      sha256 "c160390810e79ef0b35888538f0a8b0bf1b8da5ca5ea0af77257ecc8c80f8a22"
     else
       url "https://github.com/samzong/mdctl/releases/download/v#{version}/mdctl_Linux_x86_64.tar.gz"
-      sha256 "d30d4727eb24dcf95dbc0d903c20e52382641d9731904fdd4c123ef03c33573d"
+      sha256 "ed0e00e05090710bc2b75586a1fe6cf750ae5b2c2792fedc0db2d452ab7c7010"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 29da5846e97fe28592dbc9f909304ef912905e489098e68c4f332ef1cd3cd4c4\n- Darwin(arm64): 231064dce55a6de51c41b6254a43f07762f44532cbb020ab808b4ae38ed931eb