### PR TITLE
chore: update gmc to v0.0.3

### DIFF
--- a/Formula/gmc.rb
+++ b/Formula/gmc.rb
@@ -1,25 +1,25 @@
 class Gmc < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/gmc"
-  version "0.0.2"
+  version "0.0.3"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_arm64.tar.gz"
-      sha256 "f980857b2231865a11e640d4a5be3fea1182cb56c95ee70e4759b2041e462a10"
+      sha256 "631575a9207dbac7d675dc8448346f6067896d93c2f91b7b1ad0fc77e93d0016"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_x86_64.tar.gz"
-      sha256 "691fc452f73174dd4daa4c0440c88b08c6c08a3bcd1efe1cfa3c78f389722823"
+      sha256 "6d5d7f85a1c51fee9d33f5e1ff5e5a86406ff62bbd46badd10988869081f358c"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_arm64.tar.gz"
-      sha256 "e44431893b6dc61d4ea896615c84ed683fe9c2f99ddd7113cc6d296b77e8c16f"
+      sha256 "fd4a6e23a29d1978d3ec88e6387d72bf56af3c9d467e1ff7de68f8e2d0b0af44"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_x86_64.tar.gz"
-      sha256 "2dd2b06fda3e98278182708a762a2cdfb4df827bd20cd461b09fb757f7072e85"
+      sha256 "5eace8624529fdcf8d7d8f9da57e127ffc1213f28478ec3e4f870d2245faf411"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 6d5d7f85a1c51fee9d33f5e1ff5e5a86406ff62bbd46badd10988869081f358c\n- Darwin(arm64): 631575a9207dbac7d675dc8448346f6067896d93c2f91b7b1ad0fc77e93d0016