### PR TITLE
chore: update gmc to v0.0.4

### DIFF
--- a/Formula/gmc.rb
+++ b/Formula/gmc.rb
@@ -1,25 +1,25 @@
 class Gmc < Formula
   desc "A CLI tool for managing markdown files"
   homepage "https://github.com/samzong/gmc"
-  version "0.0.3"
+  version "0.0.4"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_arm64.tar.gz"
-      sha256 "631575a9207dbac7d675dc8448346f6067896d93c2f91b7b1ad0fc77e93d0016"
+      sha256 "fcd4601e0528fe8f56b42fb168164d910fb50c144f41926fc2c819e0e002955a"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_x86_64.tar.gz"
-      sha256 "6d5d7f85a1c51fee9d33f5e1ff5e5a86406ff62bbd46badd10988869081f358c"
+      sha256 "1917168af4fa2c9ce980ef3311ab4cee9a1f2340a99988471e58dc7f4fe62753"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_arm64.tar.gz"
-      sha256 "fd4a6e23a29d1978d3ec88e6387d72bf56af3c9d467e1ff7de68f8e2d0b0af44"
+      sha256 "7db79d6b996dec9afae977f13e9269371074b24e11633833101fda82bf62063a"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_x86_64.tar.gz"
-      sha256 "5eace8624529fdcf8d7d8f9da57e127ffc1213f28478ec3e4f870d2245faf411"
+      sha256 "ed5415052e838d0b05f7d00b34b5bb6325f1a79cb218f566f39dda5366962bdc"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 1917168af4fa2c9ce980ef3311ab4cee9a1f2340a99988471e58dc7f4fe62753\n- Darwin(arm64): fcd4601e0528fe8f56b42fb168164d910fb50c144f41926fc2c819e0e002955a