### PR TITLE
chore: update prompts to v0.1.1

### DIFF
--- a/Casks/prompts.rb
+++ b/Casks/prompts.rb
@@ -1,12 +1,12 @@
 cask "prompts" do
-    version "0.1.0"
+    version "0.1.1"
   
     if Hardware::CPU.arm?
       url "https://github.com/samzong/prompts/releases/download/v#{version}/Prompts_#{version}_aarch64.dmg"
-      sha256 "c3cc63551e3e94f6f5f88c3ed2e96877eb8e8fcf02dc3115a27953f707aba35e"
+      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
     else
       url "https://github.com/samzong/prompts/releases/download/v#{version}/Prompts_#{version}_x64.dmg"
-      sha256 "42ca2db4726e6348767f2bba89f775a54379a26eabf699a3e5a34a3c2bac1c71"
+      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
     end
   
     name "Prompts"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.1.1
- ARM64 SHA256: 
- x86_64 SHA256: 