### PR TITLE
chore: update prompts to v0.1.2

### DIFF
--- a/Casks/prompts.rb
+++ b/Casks/prompts.rb
@@ -1,12 +1,12 @@
 cask "prompts" do
-    version "0.1.1"
+    version "0.1.2"
   
     if Hardware::CPU.arm?
       url "https://github.com/samzong/prompts/releases/download/v#{version}/Prompts_#{version}_aarch64.dmg"
-      sha256 "7634439596857292b08300a6aab5468501973c7a764a9d402ad92d6cdcf872cb"
+      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
     else
       url "https://github.com/samzong/prompts/releases/download/v#{version}/Prompts_#{version}_x64.dmg"
-      sha256 "e67fedbe6b284f6d748079b250889ba4b8049597200dfb6e298e9c50ef1d4501"
+      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
     end
   
     name "Prompts"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.1.2
- ARM64 SHA256: 
- x86_64 SHA256: 