### PR TITLE
chore: update hf-model-downloader to v0.0.5

### DIFF
--- a/Casks/hf-model-downloader.rb
+++ b/Casks/hf-model-downloader.rb
@@ -1,6 +1,6 @@
 cask "hf-model-downloader" do
   app "HF Model Downloader.app"
-  version "0.0.4"
+  version "0.0.5"
 
   name "HF Model Downloader"
   desc "A GUI tool for downloading Hugging Face models"
@@ -10,10 +10,10 @@ cask "hf-model-downloader" do
 
   if Hardware::CPU.arm?
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-arm64.dmg"
-    sha256 "185f00f235c4475be393d437007c8b0474007913e2693cb02a54cb1eca5150f0"
+    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
   else
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-x86_64.dmg"
-    sha256 "983d38d7be9ab3fbc570a97331688239a2f25945757ee4da657ae34584d3c5bd"
+    sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
   end
 
   zap trash: [


### PR DESCRIPTION
Auto-generated PR

- Version: 0.0.5
- ARM64 SHA256: 
- x86_64 SHA256: 