### PR TITLE
chore: update MacMusicPlayer to v0.4.0

### DIFF
--- a/Casks/mac-music-player.rb
+++ b/Casks/mac-music-player.rb
@@ -1,11 +1,11 @@
 cask "mac-music-player" do
-  version "0.3.1"
+  version "0.4.0"
   if Hardware::CPU.arm?
     url "https://github.com/samzong/MacMusicPlayer/releases/download/v#{version}/MacMusicPlayer-arm64.dmg"
-    sha256 "686ab57c26bee429adca98b0d0bbdf85b4e1835fa3860aff2e647aca791225d4"
+    sha256 "941495a0c49f990be8894237bd3f4fe20be213e2afa5305479b3da45e556a669"
   else
     url "https://github.com/samzong/MacMusicPlayer/releases/download/v#{version}/MacMusicPlayer-x86_64.dmg"
-    sha256 "7e4874e35a9d85985c52d8844bf906c24412ba58138268580119846b6c572a05"
+    sha256 "2f7f214b313ddab16716a53ea856ab059b2733ac2bb58bb02b137b9996897769"
   end
 
   name "MacMusicPlayer"


### PR DESCRIPTION
Auto-generated PR
- Version: 0.4.0
- x86_64 SHA256: 
- arm64 SHA256: 