### PR TITLE
chore: update gofs to v0.1.2

### DIFF
--- a/Formula/gofs.rb
+++ b/Formula/gofs.rb
@@ -1,25 +1,25 @@
 class Gofs < Formula
   desc "A lightweight, fast HTTP file server written in Go."
   homepage "https://github.com/samzong/gofs"
-  version "0.1.1"
+  version "0.1.2"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_arm64.tar.gz"
-      sha256 "5dd7440ebb8cf2920881576b86d187e8eba32cd1812a6c8f9e176430a0ad91a9"
+      sha256 "0d5ae0bf5203c1c4f0a02691dd8742664b991f4ae8f3350fdc14f54cd23c4521"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_x86_64.tar.gz"
-      sha256 "f97b4f09d6fb48a77770f44e83ec5024821e190e03f5d69dffb1f1d8ef7fd436"
+      sha256 "0d7fc377be1d2f7f9e88f344a7e0d3a742189608fe84dc565cec24a8deb1a498"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_arm64.tar.gz"
-      sha256 "d6ba41c9abe96a02cee25cf92560eabc4f6b7c1899fbad385b7ec7ecaf49dea1"
+      sha256 "fb92a71ef44193c078f8a1bc84693c1ffa00322e7aac1fd74da3972d54a85d52"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_x86_64.tar.gz"
-      sha256 "8ef4ac7a396eec309d110826011b8aeb3e2dcd1e15dfe5cda28eb4985fe223a5"
+      sha256 "94980e6126187fc9f4a681c9c37e6e1110eed16edad3d833efed9c71c4e56248"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 0d7fc377be1d2f7f9e88f344a7e0d3a742189608fe84dc565cec24a8deb1a498\n- Darwin(arm64): 0d5ae0bf5203c1c4f0a02691dd8742664b991f4ae8f3350fdc14f54cd23c4521