### PR TITLE
chore: update gofs to v0.1.3

### DIFF
--- a/Formula/gofs.rb
+++ b/Formula/gofs.rb
@@ -1,25 +1,25 @@
 class Gofs < Formula
   desc "A lightweight, fast HTTP file server written in Go."
   homepage "https://github.com/samzong/gofs"
-  version "0.1.2"
+  version "0.1.3"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_arm64.tar.gz"
-      sha256 "0d5ae0bf5203c1c4f0a02691dd8742664b991f4ae8f3350fdc14f54cd23c4521"
+      sha256 "72a5ea19aebb669609da6344f96702b620ef3ed201fab95744aa49d72364e588"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_x86_64.tar.gz"
-      sha256 "0d7fc377be1d2f7f9e88f344a7e0d3a742189608fe84dc565cec24a8deb1a498"
+      sha256 "ceed3aa3dde8aec7abaae3d717e6b10a81af503190df60226a99f293e6404ef2"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_arm64.tar.gz"
-      sha256 "fb92a71ef44193c078f8a1bc84693c1ffa00322e7aac1fd74da3972d54a85d52"
+      sha256 "6588fce6651361dd526427f88b07406604c1f1006d94906e1521bf1b8733370e"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_x86_64.tar.gz"
-      sha256 "94980e6126187fc9f4a681c9c37e6e1110eed16edad3d833efed9c71c4e56248"
+      sha256 "84c4f5a01420c5d1f3257e1b801111ae4b198b363fb0e282fee496541c5d5335"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): ceed3aa3dde8aec7abaae3d717e6b10a81af503190df60226a99f293e6404ef2\n- Darwin(arm64): 72a5ea19aebb669609da6344f96702b620ef3ed201fab95744aa49d72364e588