### PR TITLE
chore: update gofs to v0.1.4-1-g94209f7

### DIFF
--- a/Formula/gofs.rb
+++ b/Formula/gofs.rb
@@ -1,25 +1,25 @@
 class Gofs < Formula
   desc "A lightweight, fast HTTP file server written in Go."
   homepage "https://github.com/samzong/gofs"
-  version "0.1.3"
+  version "0.1.4"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_arm64.tar.gz"
-      sha256 "72a5ea19aebb669609da6344f96702b620ef3ed201fab95744aa49d72364e588"
+      sha256 "f9ec8b889137e955a884fc0054e358d1d3287b8e8278f3f6a76a27c0e465f23a"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_x86_64.tar.gz"
-      sha256 "ceed3aa3dde8aec7abaae3d717e6b10a81af503190df60226a99f293e6404ef2"
+      sha256 "bff25a788923c0027511804948b43fb2d70976bb35621dc9aaacdde3af3f0dd6"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_arm64.tar.gz"
-      sha256 "6588fce6651361dd526427f88b07406604c1f1006d94906e1521bf1b8733370e"
+      sha256 "ee51c3e84f59b2c57521ff44845e6f304c0d308aedf0fabd36771e9ae48d4446"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_x86_64.tar.gz"
-      sha256 "84c4f5a01420c5d1f3257e1b801111ae4b198b363fb0e282fee496541c5d5335"
+      sha256 "c16cab4e77698fbf773f605776ff02d318cace8b56106ffde19153617f659031"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): bff25a788923c0027511804948b43fb2d70976bb35621dc9aaacdde3af3f0dd6\n- Darwin(arm64): f9ec8b889137e955a884fc0054e358d1d3287b8e8278f3f6a76a27c0e465f23a