### PR TITLE
chore: update gofs to v0.1.5

### DIFF
--- a/Formula/gofs.rb
+++ b/Formula/gofs.rb
@@ -1,25 +1,25 @@
 class Gofs < Formula
   desc "A lightweight, fast HTTP file server written in Go."
   homepage "https://github.com/samzong/gofs"
-  version "0.1.4"
+  version "0.1.5"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_arm64.tar.gz"
-      sha256 "f9ec8b889137e955a884fc0054e358d1d3287b8e8278f3f6a76a27c0e465f23a"
+      sha256 "21ef2aac3f9aaa1577b8c89fd5f5c5e995562b5373ebb1cd83f5c93b5eccfefc"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_x86_64.tar.gz"
-      sha256 "bff25a788923c0027511804948b43fb2d70976bb35621dc9aaacdde3af3f0dd6"
+      sha256 "cb65419765a7f9dfaa54cdfee768ebecd7348e2dbe5af855d8d528d735cd3cc9"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_arm64.tar.gz"
-      sha256 "ee51c3e84f59b2c57521ff44845e6f304c0d308aedf0fabd36771e9ae48d4446"
+      sha256 "158cbbf47f4d7d488ceb3bd46d8cc9796325db8d43d5615f99aaa498799f287a"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_x86_64.tar.gz"
-      sha256 "c16cab4e77698fbf773f605776ff02d318cace8b56106ffde19153617f659031"
+      sha256 "2cee48c20da9f4905b81aefadaa8800d158b92f5121e61fa625d9946b64f3b2a"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): cb65419765a7f9dfaa54cdfee768ebecd7348e2dbe5af855d8d528d735cd3cc9\n- Darwin(arm64): 21ef2aac3f9aaa1577b8c89fd5f5c5e995562b5373ebb1cd83f5c93b5eccfefc