### PR TITLE
chore: update gmc to v0.0.5

### DIFF
--- a/Formula/gmc.rb
+++ b/Formula/gmc.rb
@@ -1,25 +1,25 @@
 class Gmc < Formula
   desc "CLI for that accelerates the efficiency of Git add and commit"
   homepage "https://github.com/samzong/gmc"
-  version "0.0.4"
+  version "0.0.5"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_arm64.tar.gz"
-      sha256 "fcd4601e0528fe8f56b42fb168164d910fb50c144f41926fc2c819e0e002955a"
+      sha256 "2277eb13a5cb892881f89cbec8e4177cb5f7fef976b479602981ba34c88ebce4"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_x86_64.tar.gz"
-      sha256 "1917168af4fa2c9ce980ef3311ab4cee9a1f2340a99988471e58dc7f4fe62753"
+      sha256 "1563b8ae45453b321617f64e688d924a6dc91d50cba86b51674563444a7ae3bf"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_arm64.tar.gz"
-      sha256 "7db79d6b996dec9afae977f13e9269371074b24e11633833101fda82bf62063a"
+      sha256 "7e0538c9b849eeedd0cef0a32815898e10f18924fbe56e963b1505fdc2e38e98"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_x86_64.tar.gz"
-      sha256 "ed5415052e838d0b05f7d00b34b5bb6325f1a79cb218f566f39dda5366962bdc"
+      sha256 "acbf1e6c18bdac3b2214b92b5c4654f1f00b4efad0cb801ff7f27d40c839060c"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): 1563b8ae45453b321617f64e688d924a6dc91d50cba86b51674563444a7ae3bf\n- Darwin(arm64): 2277eb13a5cb892881f89cbec8e4177cb5f7fef976b479602981ba34c88ebce4