### PR TITLE
chore: update gofs to v0.2.0

### DIFF
--- a/Formula/gofs.rb
+++ b/Formula/gofs.rb
@@ -1,25 +1,25 @@
 class Gofs < Formula
   desc "A lightweight, fast HTTP file server written in Go."
   homepage "https://github.com/samzong/gofs"
-  version "0.1.5"
+  version "0.2.0"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_arm64.tar.gz"
-      sha256 "21ef2aac3f9aaa1577b8c89fd5f5c5e995562b5373ebb1cd83f5c93b5eccfefc"
+      sha256 "ae7210b3e9c3f57550d78b76f8df47160315fd9f40ff13dde340414dcea3ca2d"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Darwin_x86_64.tar.gz"
-      sha256 "cb65419765a7f9dfaa54cdfee768ebecd7348e2dbe5af855d8d528d735cd3cc9"
+      sha256 "26867aa5b533a966eb949f826fe77ad2ed93046f21e67b1ff39bdd50b24693bc"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_arm64.tar.gz"
-      sha256 "158cbbf47f4d7d488ceb3bd46d8cc9796325db8d43d5615f99aaa498799f287a"
+      sha256 "711f67b43452e7599ae5b38385256f1418afd4e9f9e208240358181376d1bc81"
     else
       url "https://github.com/samzong/gofs/releases/download/v#{version}/gofs_Linux_x86_64.tar.gz"
-      sha256 "2cee48c20da9f4905b81aefadaa8800d158b92f5121e61fa625d9946b64f3b2a"
+      sha256 "6d98385b0d88623ee710c648a7dbb557ff2a495d356189f8261e99943c5cca69"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR to update gofs to v0.2.0

## Checksums
- Darwin (AMD64): 26867aa5b533a966eb949f826fe77ad2ed93046f21e67b1ff39bdd50b24693bc
- Darwin (ARM64): ae7210b3e9c3f57550d78b76f8df47160315fd9f40ff13dde340414dcea3ca2d  
- Linux (AMD64): 6d98385b0d88623ee710c648a7dbb557ff2a495d356189f8261e99943c5cca69
- Linux (ARM64): 711f67b43452e7599ae5b38385256f1418afd4e9f9e208240358181376d1bc81