### PR TITLE
chore: update gmc to v0.0.6

### DIFF
--- a/Formula/gmc.rb
+++ b/Formula/gmc.rb
@@ -1,25 +1,25 @@
 class Gmc < Formula
   desc "CLI for that accelerates the efficiency of Git add and commit"
   homepage "https://github.com/samzong/gmc"
-  version "0.0.5"
+  version "0.0.6"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_arm64.tar.gz"
-      sha256 "2277eb13a5cb892881f89cbec8e4177cb5f7fef976b479602981ba34c88ebce4"
+      sha256 "176faf5f75eacff5915c6637d01c559ae5f3f387894d9809870ff45d0e073ef2"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Darwin_x86_64.tar.gz"
-      sha256 "1563b8ae45453b321617f64e688d924a6dc91d50cba86b51674563444a7ae3bf"
+      sha256 "df3e0490fef8f9ea723d31a58b5bfc2c1ee2b74b74ae62ded01a20468475082e"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_arm64.tar.gz"
-      sha256 "7e0538c9b849eeedd0cef0a32815898e10f18924fbe56e963b1505fdc2e38e98"
+      sha256 "d478baffb0b3a36987affc125827147943785f08af449025aefd1a933bb4d496"
     else
       url "https://github.com/samzong/gmc/releases/download/v#{version}/gmc_Linux_x86_64.tar.gz"
-      sha256 "acbf1e6c18bdac3b2214b92b5c4654f1f00b4efad0cb801ff7f27d40c839060c"
+      sha256 "dcaac23c00afc9ba6cd0d77dc82b942fd8e4a684d46de9686afabb3dead9a8b0"
     end
   end
 


### PR DESCRIPTION
Auto-generated PR\nSHAs:\n- Darwin(amd64): df3e0490fef8f9ea723d31a58b5bfc2c1ee2b74b74ae62ded01a20468475082e\n- Darwin(arm64): 176faf5f75eacff5915c6637d01c559ae5f3f387894d9809870ff45d0e073ef2