### PR TITLE
chore: update hf-model-downloader to v0.0.7

### DIFF
--- a/Casks/hf-model-downloader.rb
+++ b/Casks/hf-model-downloader.rb
@@ -1,5 +1,5 @@
 cask "hf-model-downloader" do
-  version "0.0.6"
+  version "0.0.7"
 
   name "HF Model Downloader"
   desc "A GUI tool for downloading Hugging Face models"
@@ -16,12 +16,12 @@ cask "hf-model-downloader" do
 
   on_arm do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-arm64.dmg"
-    sha256 "80385b7a008ef378a1c8b364128584957bb84ecac7b6a5d8255dd8a5aa11d2cc"
+    sha256 "556b42df029878099702f7c762b546709b014874e0e0fa1d8b6ca822f1f11b78"
   end
 
   on_intel do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-x86_64.dmg"
-    sha256 "627685831a39633671cecab9be2ba4bcb6020ed15e0351c8fb44a0664f494fa6"
+    sha256 "43073c824c3427aeac933c330e118e541f7586ee2eccbf58c03981a406195f8c"
   end
 
   app "HF Model Downloader.app"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.0.7
- ARM64 SHA256: 
- x86_64 SHA256: 