### PR TITLE
chore: update hf-model-downloader to v0.3.3

### DIFF
--- a/Casks/hf-model-downloader.rb
+++ b/Casks/hf-model-downloader.rb
@@ -1,5 +1,5 @@
 cask "hf-model-downloader" do
-  version "0.3.2"
+  version "0.3.3"
 
   name "HF Model Downloader"
   desc "A GUI tool for downloading Hugging Face models"
@@ -16,12 +16,12 @@ cask "hf-model-downloader" do
 
   on_arm do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-arm64.dmg"
-    sha256 "a8c50c4fd26209b1c825b59e01f61bbabe35b0d4f586d837702b45363d4d118d"
+    sha256 "e0ec6d614266a9af1b3c113b6e2f98c1fac80f2f4d6a6e021bddf35a7ba412e7"
   end
 
   on_intel do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-x86_64.dmg"
-    sha256 "7d8133d9fd5966a8d7b84a9d895deebbae90f03fdd1fd2a8db49ed8d6ddc802d"
+    sha256 "77e948a84423479486401964581dc36f6fa15f5b5d7b14297f2bc55a2ac60107"
   end
 
   app "HF Model Downloader.app"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.3.3
- ARM64 SHA256: e0ec6d614266a9af1b3c113b6e2f98c1fac80f2f4d6a6e021bddf35a7ba412e7
- x86_64 SHA256: 77e948a84423479486401964581dc36f6fa15f5b5d7b14297f2bc55a2ac60107
