### PR TITLE
chore: update hf-model-downloader to v0.5.4

### DIFF
--- a/Casks/hf-model-downloader.rb
+++ b/Casks/hf-model-downloader.rb
@@ -1,5 +1,5 @@
 cask "hf-model-downloader" do
-  version "0.5.3"
+  version "0.5.4"
 
   name "HF Model Downloader"
   desc "A GUI tool for downloading Hugging Face models"
@@ -16,12 +16,12 @@ cask "hf-model-downloader" do
 
   on_arm do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-arm64.dmg"
-    sha256 "6263f76aab30689ed7330e5ed00eee210c337a7c00d14852048ec6a944cdcd70"
+    sha256 "da00e7f79cccd071b16762ac59811f9b80cb43d0ab06ddbf9e5cc9383130b42e"
   end
 
   on_intel do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-x86_64.dmg"
-    sha256 "1477231c2d5b6c9a662c3b3d28fcfe9381776ef0f293b71f40066dc9724578a1"
+    sha256 "e336250492b6517db2a5038b33aacd9853ad6e4ad63e822e81886049d91d97b9"
   end
 
   app "HF Model Downloader.app"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.5.4
- ARM64 SHA256: da00e7f79cccd071b16762ac59811f9b80cb43d0ab06ddbf9e5cc9383130b42e
- x86_64 SHA256: e336250492b6517db2a5038b33aacd9853ad6e4ad63e822e81886049d91d97b9
