### PR TITLE
chore: update hf-model-downloader to v0.6.0

### DIFF
--- a/Casks/hf-model-downloader.rb
+++ b/Casks/hf-model-downloader.rb
@@ -1,5 +1,5 @@
 cask "hf-model-downloader" do
-  version "0.5.5"
+  version "0.6.0"
 
   name "HF Model Downloader"
   desc "A GUI tool for downloading Hugging Face models"
@@ -16,12 +16,12 @@ cask "hf-model-downloader" do
 
   on_arm do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-arm64.dmg"
-    sha256 "b14bf3e118be63a79e42bd9c0df8118094ba2853849e3776bdd3e5b76329f4fe"
+    sha256 "8528ff110122acf292911f32b4d6b9ac75bce9a867c549aab7b3f55c528b55fe"
   end
 
   on_intel do
     url "https://github.com/samzong/hf-model-downloader/releases/download/v#{version}/hf-model-downloader-x86_64.dmg"
-    sha256 "e7f6637e1d95b87209e614a3fb3b9eba26cfcc97b6d62f5b09955eee5799bb66"
+    sha256 "617a17983361bf441bc61c14ecd8ef55169238fd49ad6e20e2ef47857dccd258"
   end
 
   app "HF Model Downloader.app"


### PR DESCRIPTION
Auto-generated PR

- Version: 0.6.0
- ARM64 SHA256: 8528ff110122acf292911f32b4d6b9ac75bce9a867c549aab7b3f55c528b55fe
- x86_64 SHA256: 617a17983361bf441bc61c14ecd8ef55169238fd49ad6e20e2ef47857dccd258
