### PR TITLE
[Feat] Add brew-releaser action for automated Cask and Formula updates

### DIFF
--- a/.github/workflows/idoc.yml
+++ b/.github/workflows/idoc.yml
@@ -11,7 +11,7 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,7 +11,7 @@ jobs:
   verify-sha256:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
     needs: verify-sha256
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -20,7 +20,7 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/README.md
+++ b/README.md
@@ -37,20 +37,27 @@ brew install mdctl
 | mm | CLI Tool | CLI for that help you fast to contribution to projects | v0.0.5 |
 | ConfigForge | GUI App | Open-source SSH configuration and Kubernetes configuration management tool | v0.2.1 |
 
+## brew-releaser
+
+This tap ships a reusable GitHub Action for automating Homebrew Cask and Formula updates.
+
+```yaml
+- uses: samzong/homebrew-tap/actions/brew-releaser@main
+  with:
+    type: cask          # or formula
+    version: "1.0.0"
+    app_name: MyApp
+    dmg_url: "https://github.com/…/MyApp-arm64.dmg"
+    token: ${{ secrets.GH_PAT }}
+```
+
+See [actions/brew-releaser/README.md](actions/brew-releaser/README.md) for full documentation.
+
 ## Documentation
 
 - `brew help`
 - `man brew`
 - [Homebrew's documentation](https://docs.brew.sh)
-
-### Cask App Unsigned
-
-```ruby
-  # other install step
-  postflight do
-    system_command "xattr", args: ["-cr", "#{appdir}/Prompts.app"]
-  end
-```
 
 ## License
 

--- a/actions/brew-releaser/README.md
+++ b/actions/brew-releaser/README.md
@@ -1,0 +1,159 @@
+# brew-releaser
+
+GitHub Action that creates or updates Homebrew **Cask** and **Formula** files in a tap repository. Downloads release artifacts, computes SHA256 checksums, and opens a pull request — fully automated.
+
+## Features
+
+- **Cask + Formula** — supports both macOS app (`.dmg`) and CLI tool (`.tar.gz`) distribution
+- **Auto-create** — generates a new Cask/Formula from scratch on first release; updates in-place on subsequent releases
+- **Multi-arch** — arm64-only, x86_64-only, or dual-architecture
+- **Multi-platform** — Formula supports macOS + Linux combinations
+- **Zero-config tap** — no manual file creation needed in the tap repository
+- **Configurable** — works with any tap repo, not just the one hosting this action
+
+## Usage
+
+### Cask (macOS app)
+
+```yaml
+- uses: samzong/homebrew-tap/actions/brew-releaser@v1
+  with:
+    type: cask
+    version: "1.0.0"
+    app_name: Mote
+    dmg_url: "https://github.com/samzong/Mote/releases/download/v1.0.0/Mote-arm64.dmg"
+    desc: "macOS background app that rewrites selected text system-wide"
+    min_macos: ":sequoia"
+    token: ${{ secrets.GH_PAT }}
+```
+
+### Cask (dual architecture)
+
+```yaml
+- uses: samzong/homebrew-tap/actions/brew-releaser@v1
+  with:
+    type: cask
+    version: "0.2.1"
+    app_name: ConfigForge
+    dmg_url: "https://github.com/samzong/ConfigForge/releases/download/v0.2.1/ConfigForge-arm64.dmg"
+    dmg_x86_url: "https://github.com/samzong/ConfigForge/releases/download/v0.2.1/ConfigForge-x86_64.dmg"
+    desc: "SSH and Kubernetes configuration management tool"
+    token: ${{ secrets.GH_PAT }}
+```
+
+### Formula (CLI tool)
+
+```yaml
+- uses: samzong/homebrew-tap/actions/brew-releaser@v1
+  with:
+    type: formula
+    version: "0.8.0"
+    app_name: gmc
+    formula_urls: |
+      {
+        "darwin-arm64": "https://github.com/samzong/gmc/releases/download/v0.8.0/gmc_Darwin_arm64.tar.gz",
+        "darwin-x86_64": "https://github.com/samzong/gmc/releases/download/v0.8.0/gmc_Darwin_x86_64.tar.gz",
+        "linux-arm64": "https://github.com/samzong/gmc/releases/download/v0.8.0/gmc_Linux_arm64.tar.gz",
+        "linux-x86_64": "https://github.com/samzong/gmc/releases/download/v0.8.0/gmc_Linux_x86_64.tar.gz"
+      }
+    desc: "CLI that accelerates Git add and commit"
+    license: MIT
+    token: ${{ secrets.GH_PAT }}
+```
+
+### Full release workflow example
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - id: v
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+      - run: make dmg
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: .build/*-arm64.dmg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: samzong/homebrew-tap/actions/brew-releaser@v1
+        with:
+          type: cask
+          version: ${{ steps.v.outputs.version }}
+          app_name: Mote
+          dmg_url: "https://github.com/${{ github.repository }}/releases/download/v${{ steps.v.outputs.version }}/Mote-arm64.dmg"
+          desc: "macOS background app that rewrites selected text system-wide"
+          min_macos: ":sequoia"
+          token: ${{ secrets.GH_PAT }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `type` | **yes** | — | `cask` or `formula` |
+| `version` | **yes** | — | Version without `v` prefix |
+| `app_name` | **yes** | — | Application or binary name |
+| `token` | **yes** | — | GitHub PAT with tap repo write access |
+| `tap_repo` | no | `samzong/homebrew-tap` | Target tap in `owner/repo` format |
+| `file_path` | no | auto | Path in tap (e.g. `Casks/my-app.rb`) |
+| `desc` | no | `{app_name}` | Short description |
+| `homepage` | no | auto | Homepage URL |
+| `dmg_url` | cask | — | arm64 DMG download URL |
+| `dmg_x86_url` | no | — | x86_64 DMG download URL |
+| `min_macos` | no | `:sonoma` | Minimum macOS version symbol |
+| `formula_urls` | formula | — | JSON object of platform-arch → URL |
+| `binary_name` | no | `{app_name}` | Binary name for `bin.install` |
+| `license` | no | — | SPDX license identifier |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `pr_url` | URL of the created pull request |
+| `file_path` | Path to the Cask/Formula file in the tap |
+
+## How it works
+
+```
+1. Validate inputs, resolve file path
+2. Download release artifacts (DMG or tar.gz)
+3. Compute SHA256 checksums (cross-platform: sha256sum / shasum)
+4. Clone tap repo, create branch
+5. If file exists → sed update version + SHA256
+   If file missing → generate from template
+6. Commit, push, open PR
+```
+
+## Conventions
+
+### DMG naming (Cask)
+
+```
+{APP_NAME}-arm64.dmg        # arm64
+{APP_NAME}-x86_64.dmg       # Intel (optional)
+```
+
+Version goes in the URL path (`/v1.0.0/`), not in the filename.
+
+### tar.gz naming (Formula)
+
+```
+{binary}_Darwin_arm64.tar.gz
+{binary}_Darwin_x86_64.tar.gz
+{binary}_Linux_arm64.tar.gz
+{binary}_Linux_x86_64.tar.gz
+```
+
+## Requirements
+
+- `jq` must be available on the runner (pre-installed on GitHub-hosted runners)
+- `curl`, `git`, `sed` (standard on all runners)
+- The `token` must have `contents:write` and `pull_requests:write` on the tap repo

--- a/actions/brew-releaser/action.yml
+++ b/actions/brew-releaser/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "[Formula] SPDX license identifier (e.g. MIT, Apache-2.0)"
     required: false
     default: ""
+  skip_quarantine:
+    description: "[Cask] Add postflight xattr -cr to remove quarantine (default: true)"
+    required: false
+    default: "true"
 
 outputs:
   pr_url:
@@ -92,9 +96,10 @@ runs:
         INPUT_FORMULA_URLS: ${{ inputs.formula_urls }}
         INPUT_BINARY_NAME: ${{ inputs.binary_name }}
         INPUT_LICENSE: ${{ inputs.license }}
+        INPUT_SKIP_QUARANTINE: ${{ inputs.skip_quarantine }}
       run: bash "${{ github.action_path }}/entrypoint.sh"
 
     - name: Cleanup
       if: always()
       shell: bash
-      run: rm -rf tap /tmp/brew-releaser-*
+      run: rm -rf /tmp/brew-releaser-*

--- a/actions/brew-releaser/action.yml
+++ b/actions/brew-releaser/action.yml
@@ -1,0 +1,100 @@
+name: brew-releaser
+description: >
+  Create or update Homebrew Cask and Formula files in a tap repository.
+  Downloads release artifacts, computes SHA256, and opens a PR automatically.
+
+branding:
+  icon: package
+  color: orange
+
+inputs:
+  type:
+    description: "Package type: cask (macOS .app) or formula (CLI binary)"
+    required: true
+  version:
+    description: "Semantic version without v prefix (e.g. 1.2.0)"
+    required: true
+  app_name:
+    description: "Application/binary name (e.g. Mote, gmc)"
+    required: true
+  token:
+    description: "GitHub token with contents:write and pull_requests:write on the tap repo"
+    required: true
+  tap_repo:
+    description: "Tap repository in owner/name format"
+    required: false
+    default: "samzong/homebrew-tap"
+  file_path:
+    description: "Path to Cask/Formula file in tap (auto-derived from type + app_name if omitted)"
+    required: false
+    default: ""
+  desc:
+    description: "Short description (falls back to app_name if empty)"
+    required: false
+    default: ""
+  homepage:
+    description: "Homepage URL (default: https://github.com/{tap_owner}/{app_name})"
+    required: false
+    default: ""
+  dmg_url:
+    description: "[Cask] Download URL for arm64 DMG"
+    required: false
+    default: ""
+  dmg_x86_url:
+    description: "[Cask] Download URL for x86_64 DMG (omit for arm64-only)"
+    required: false
+    default: ""
+  min_macos:
+    description: "[Cask] Minimum macOS version symbol (e.g. :sequoia, :sonoma)"
+    required: false
+    default: ":sonoma"
+  formula_urls:
+    description: >
+      [Formula] JSON object mapping platform-arch to download URLs.
+      Keys: darwin-arm64, darwin-x86_64, linux-arm64, linux-x86_64
+    required: false
+    default: ""
+  binary_name:
+    description: "[Formula] Binary name to install (defaults to app_name lowercase)"
+    required: false
+    default: ""
+  license:
+    description: "[Formula] SPDX license identifier (e.g. MIT, Apache-2.0)"
+    required: false
+    default: ""
+
+outputs:
+  pr_url:
+    description: "URL of the created pull request"
+    value: ${{ steps.run.outputs.pr_url }}
+  file_path:
+    description: "Path to the created/updated file in the tap"
+    value: ${{ steps.run.outputs.file_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run brew-releaser
+      id: run
+      shell: bash
+      env:
+        INPUT_TYPE: ${{ inputs.type }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_APP_NAME: ${{ inputs.app_name }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_TAP_REPO: ${{ inputs.tap_repo }}
+        INPUT_FILE_PATH: ${{ inputs.file_path }}
+        INPUT_DESC: ${{ inputs.desc }}
+        INPUT_HOMEPAGE: ${{ inputs.homepage }}
+        INPUT_DMG_URL: ${{ inputs.dmg_url }}
+        INPUT_DMG_X86_URL: ${{ inputs.dmg_x86_url }}
+        INPUT_MIN_MACOS: ${{ inputs.min_macos }}
+        INPUT_FORMULA_URLS: ${{ inputs.formula_urls }}
+        INPUT_BINARY_NAME: ${{ inputs.binary_name }}
+        INPUT_LICENSE: ${{ inputs.license }}
+      run: bash "${{ github.action_path }}/entrypoint.sh"
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf tap /tmp/brew-releaser-*

--- a/actions/brew-releaser/entrypoint.sh
+++ b/actions/brew-releaser/entrypoint.sh
@@ -19,6 +19,15 @@ download() {
 
 die() { echo "::error::$1"; exit 1; }
 
+gh_api() {
+  local method="$1" endpoint="$2"
+  shift 2
+  curl -fsSL -X "$method" \
+    -H "Authorization: token ${TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com${endpoint}" "$@"
+}
+
 # --- Resolve inputs ---
 
 TYPE="$INPUT_TYPE"
@@ -32,6 +41,7 @@ HOMEPAGE="${INPUT_HOMEPAGE:-https://github.com/${TAP_OWNER}/${APP_NAME}}"
 DESC="${INPUT_DESC:-${APP_NAME}}"
 BIN="${INPUT_BINARY_NAME:-${APP_LOWER}}"
 BUNDLE_ID="com.${TAP_OWNER}.${APP_LOWER}"
+SKIP_QUARANTINE="${INPUT_SKIP_QUARANTINE:-true}"
 WORKDIR=$(mktemp -d /tmp/brew-releaser-XXXXXX)
 
 [[ "$TYPE" == "cask" || "$TYPE" == "formula" ]] || die "type must be 'cask' or 'formula', got '$TYPE'"
@@ -74,54 +84,58 @@ else
 fi
 echo "::endgroup::"
 
-# --- Clone tap ---
+# --- Fetch existing file via API (no git clone) ---
 
-echo "::group::Clone tap"
-git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/${TAP_REPO}.git" tap
-cd tap
-BRANCH="brew-releaser/${APP_LOWER}-${VERSION}"
-git checkout -b "$BRANCH"
+echo "::group::Fetch tap state"
+MAIN_SHA=$(gh_api GET "/repos/${TAP_REPO}/git/ref/heads/main" | jq -r '.object.sha')
+echo "  main HEAD: $MAIN_SHA"
+
+EXISTING_CONTENT=""
+EXISTING_SHA=""
+FILE_RESPONSE=$(gh_api GET "/repos/${TAP_REPO}/contents/${FILE_PATH}?ref=main" 2>/dev/null || echo '{"message":"Not Found"}')
+if echo "$FILE_RESPONSE" | jq -e '.sha' &>/dev/null; then
+  EXISTING_SHA=$(echo "$FILE_RESPONSE" | jq -r '.sha')
+  EXISTING_CONTENT=$(echo "$FILE_RESPONSE" | jq -r '.content' | base64 -d)
+  echo "  Found existing $FILE_PATH ($EXISTING_SHA)"
+else
+  echo "  $FILE_PATH not found — will create"
+fi
 echo "::endgroup::"
 
-# --- Create or update file ---
+# --- Generate file content ---
 
-if [ -f "$FILE_PATH" ]; then
-  echo "::group::Update existing $TYPE"
+echo "::group::Generate $TYPE content"
 
-  sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$FILE_PATH"
+if [ -n "$EXISTING_CONTENT" ]; then
+  NEW_CONTENT="$EXISTING_CONTENT"
+
+  NEW_CONTENT=$(echo "$NEW_CONTENT" | sed 's/^  version "[^"]*"/  version "'"${VERSION}"'"/')
 
   if [ "$TYPE" = "cask" ]; then
-    if grep -q "on_arm" "$FILE_PATH"; then
-      sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHAS[arm64]}\"/;}" "$FILE_PATH"
+    if echo "$NEW_CONTENT" | grep -q "on_arm"; then
+      NEW_CONTENT=$(echo "$NEW_CONTENT" | sed '/on_arm/,/end/{s/sha256 "[^"]*"/sha256 "'"${SHAS[arm64]}"'"/;}')
       if [ -n "${SHAS[x86_64]:-}" ]; then
-        sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHAS[x86_64]}\"/;}" "$FILE_PATH"
+        NEW_CONTENT=$(echo "$NEW_CONTENT" | sed '/on_intel/,/end/{s/sha256 "[^"]*"/sha256 "'"${SHAS[x86_64]}"'"/;}')
       fi
     else
-      sed -i "s/sha256 \"[^\"]*\"/sha256 \"${SHAS[arm64]}\"/" "$FILE_PATH"
+      NEW_CONTENT=$(echo "$NEW_CONTENT" | sed 's/^  sha256 "[^"]*"/  sha256 "'"${SHAS[arm64]}"'"/')
     fi
   else
-    update_formula_sha() {
-      local platform="$1" arch="$2"
-      local safe="${platform}_${arch}"
-      local sha="${SHAS[$safe]:-}"
-      [ -z "$sha" ] && return
-      local os_block
-      [ "$platform" = "darwin" ] && os_block="on_macos" || os_block="on_linux"
-      local cpu_check
-      [ "$arch" = "arm64" ] && cpu_check="arm?" || cpu_check="intel?"
+    for platform in darwin linux; do
+      for arch in arm64 x86_64; do
+        safe="${platform}_${arch}"
+        sha="${SHAS[$safe]:-}"
+        [ -z "$sha" ] && continue
+        url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform}-${arch}" '.[$k] // empty')
+        [ -z "$url" ] && continue
 
-      local url
-      url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform}-${arch}" '.[$k] // empty')
-      [ -z "$url" ] && return
+        [ "$platform" = "darwin" ] && os_block="on_macos" || os_block="on_linux"
+        [ "$arch" = "arm64" ] && cpu_check="arm?" || cpu_check="intel?"
 
-      python3 - "$FILE_PATH" "$os_block" "$cpu_check" "$sha" "$url" <<'PYEOF'
-import sys, re
-path, os_block, cpu_check, sha, url = sys.argv[1:6]
-with open(path) as f:
-    content = f.read()
-pattern = rf'({os_block}\s+do.*?{re.escape(cpu_check)}.*?url\s+")[^"]*(".*?sha256\s+")[^"]*(")'
-def replacer(m):
-    return m.group(0)
+        NEW_CONTENT=$(python3 - "$os_block" "$cpu_check" "$sha" "$url" <<'PYEOF' <<< "$NEW_CONTENT"
+import sys
+os_block, cpu_check, sha, url = sys.argv[1:5]
+content = sys.stdin.read()
 lines = content.split('\n')
 in_os = False
 in_cpu = False
@@ -132,154 +146,189 @@ for line in lines:
     if in_os and cpu_check in line:
         in_cpu = True
     if in_cpu and 'url "' in line:
+        import re
         line = re.sub(r'url "[^"]*"', f'url "{url}"', line)
     if in_cpu and 'sha256 "' in line:
+        import re
         line = re.sub(r'sha256 "[^"]*"', f'sha256 "{sha}"', line)
         in_cpu = False
     if in_os and line.strip() == 'end' and not in_cpu:
         in_os = False
     result.append(line)
-with open(path, 'w') as f:
-    f.write('\n'.join(result))
+print('\n'.join(result))
 PYEOF
-    }
-
-    for platform in darwin linux; do
-      for arch in arm64 x86_64; do
-        update_formula_sha "$platform" "$arch"
+        )
       done
     done
   fi
 
-  echo "::endgroup::"
   COMMIT_VERB="update"
 else
-  echo "::group::Create new $TYPE"
-  mkdir -p "$(dirname "$FILE_PATH")"
   CASK_TOKEN=$(basename "$FILE_PATH" .rb)
 
   if [ "$TYPE" = "cask" ]; then
-    {
-      echo "cask \"${CASK_TOKEN}\" do"
-      echo "  version \"${VERSION}\""
+    NEW_CONTENT=$(cat <<EOF
+cask "${CASK_TOKEN}" do
+  version "${VERSION}"
+EOF
+    )
 
-      if [ -n "${SHAS[x86_64]:-}" ]; then
-        echo ""
-        echo "  on_arm do"
-        echo "    sha256 \"${SHAS[arm64]}\""
-        echo ""
-        echo "    url \"${INPUT_DMG_URL}\""
-        echo "  end"
-        echo "  on_intel do"
-        echo "    sha256 \"${SHAS[x86_64]}\""
-        echo ""
-        echo "    url \"${INPUT_DMG_X86_URL}\""
-        echo "  end"
-      else
-        echo "  sha256 \"${SHAS[arm64]}\""
-        echo ""
-        echo "  url \"${INPUT_DMG_URL}\""
-      fi
+    if [ -n "${SHAS[x86_64]:-}" ]; then
+      NEW_CONTENT+=$(cat <<EOF
 
-      echo ""
-      echo "  name \"${APP_NAME}\""
-      echo "  desc \"${DESC}\""
-      echo "  homepage \"${HOMEPAGE}\""
-      echo ""
-      echo "  livecheck do"
-      echo "    url :url"
-      echo "    strategy :github_latest"
-      echo "  end"
-      echo ""
-      echo "  depends_on macos: \">= ${INPUT_MIN_MACOS}\""
-      echo ""
-      echo "  app \"${APP_NAME}.app\""
-      echo ""
-      echo "  postflight do"
-      echo "    system_command \"xattr\", args: [\"-cr\", \"#{appdir}/${APP_NAME}.app\"]"
-      echo "  end"
-      echo ""
-      echo "  zap trash: ["
-      echo "    \"~/.config/${APP_LOWER}\","
-      echo "    \"~/Library/Preferences/${BUNDLE_ID}.plist\","
-      echo "    \"~/Library/Saved Application State/${BUNDLE_ID}.savedState\","
-      echo "  ]"
-      echo "end"
-    } > "$FILE_PATH"
+  on_arm do
+    sha256 "${SHAS[arm64]}"
+
+    url "${INPUT_DMG_URL}"
+  end
+  on_intel do
+    sha256 "${SHAS[x86_64]}"
+
+    url "${INPUT_DMG_X86_URL}"
+  end
+EOF
+      )
+    else
+      NEW_CONTENT+=$(cat <<EOF
+
+  sha256 "${SHAS[arm64]}"
+
+  url "${INPUT_DMG_URL}"
+EOF
+      )
+    fi
+
+    NEW_CONTENT+=$(cat <<EOF
+
+  name "${APP_NAME}"
+  desc "${DESC}"
+  homepage "${HOMEPAGE}"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= ${INPUT_MIN_MACOS}"
+
+  app "${APP_NAME}.app"
+EOF
+    )
+
+    if [ "$SKIP_QUARANTINE" = "true" ]; then
+      NEW_CONTENT+=$(cat <<EOF
+
+  postflight do
+    system_command "xattr", args: ["-cr", "#{appdir}/${APP_NAME}.app"]
+  end
+EOF
+      )
+    fi
+
+    NEW_CONTENT+=$(cat <<EOF
+
+  zap trash: [
+    "~/.config/${APP_LOWER}",
+    "~/Library/Preferences/${BUNDLE_ID}.plist",
+    "~/Library/Saved Application State/${BUNDLE_ID}.savedState",
+  ]
+end
+EOF
+    )
   else
     CLASS_NAME=$(echo "$CASK_TOKEN" | perl -pe 's/(^|[-_])(\w)/uc($2)/ge')
-    {
-      echo "class ${CLASS_NAME} < Formula"
-      echo "  desc \"${DESC}\""
-      echo "  homepage \"${HOMEPAGE}\""
-      echo "  version \"${VERSION}\""
-      [ -n "$INPUT_LICENSE" ] && echo "  license \"${INPUT_LICENSE}\""
-      echo ""
+    NEW_CONTENT="class ${CLASS_NAME} < Formula
+  desc \"${DESC}\"
+  homepage \"${HOMEPAGE}\"
+  version \"${VERSION}\""
 
-      for os in macos linux; do
-        platform_key=$( [ "$os" = "macos" ] && echo "darwin" || echo "linux" )
-        arm_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-arm64" '.[$k] // empty')
-        x86_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-x86_64" '.[$k] // empty')
-        [ -z "$arm_url" ] && [ -z "$x86_url" ] && continue
+    [ -n "$INPUT_LICENSE" ] && NEW_CONTENT+=$'\n'"  license \"${INPUT_LICENSE}\""
+    NEW_CONTENT+=$'\n'
 
-        echo "  on_${os} do"
-        if [ -n "$arm_url" ]; then
-          echo "    if Hardware::CPU.arm?"
-          echo "      url \"${arm_url}\""
-          echo "      sha256 \"${SHAS[${platform_key}_arm64]}\""
-        fi
-        if [ -n "$x86_url" ]; then
-          [ -n "$arm_url" ] && echo "    else" || echo "    if Hardware::CPU.intel?"
-          echo "      url \"${x86_url}\""
-          echo "      sha256 \"${SHAS[${platform_key}_x86_64]}\""
-        fi
-        echo "    end"
-        echo "  end"
-        echo ""
-      done
+    for os in macos linux; do
+      platform_key=$( [ "$os" = "macos" ] && echo "darwin" || echo "linux" )
+      arm_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-arm64" '.[$k] // empty')
+      x86_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-x86_64" '.[$k] // empty')
+      [ -z "$arm_url" ] && [ -z "$x86_url" ] && continue
 
-      echo "  def install"
-      echo "    bin.install \"${BIN}\""
-      echo "  end"
-      echo ""
-      echo "  test do"
-      echo "    system \"#{bin}/${BIN}\", \"--version\""
-      echo "  end"
-      echo "end"
-    } > "$FILE_PATH"
+      NEW_CONTENT+=$'\n'"  on_${os} do"
+      if [ -n "$arm_url" ]; then
+        NEW_CONTENT+=$'\n'"    if Hardware::CPU.arm?"
+        NEW_CONTENT+=$'\n'"      url \"${arm_url}\""
+        NEW_CONTENT+=$'\n'"      sha256 \"${SHAS[${platform_key}_arm64]}\""
+      fi
+      if [ -n "$x86_url" ]; then
+        [ -n "$arm_url" ] && NEW_CONTENT+=$'\n'"    else" || NEW_CONTENT+=$'\n'"    if Hardware::CPU.intel?"
+        NEW_CONTENT+=$'\n'"      url \"${x86_url}\""
+        NEW_CONTENT+=$'\n'"      sha256 \"${SHAS[${platform_key}_x86_64]}\""
+      fi
+      NEW_CONTENT+=$'\n'"    end"
+      NEW_CONTENT+=$'\n'"  end"
+      NEW_CONTENT+=$'\n'
+    done
+
+    NEW_CONTENT+=$'\n'"  def install"
+    NEW_CONTENT+=$'\n'"    bin.install \"${BIN}\""
+    NEW_CONTENT+=$'\n'"  end"
+    NEW_CONTENT+=$'\n'
+    NEW_CONTENT+=$'\n'"  test do"
+    NEW_CONTENT+=$'\n'"    system \"#{bin}/${BIN}\", \"--version\""
+    NEW_CONTENT+=$'\n'"  end"
+    NEW_CONTENT+=$'\n'"end"
   fi
 
-  echo "::endgroup::"
   COMMIT_VERB="add"
 fi
 
-echo "::group::Result"
-cat "$FILE_PATH"
+echo "$NEW_CONTENT"
 echo "::endgroup::"
 
-# --- Commit and push ---
+# --- Push via GitHub API (no git clone) ---
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git add "$FILE_PATH"
-git commit -m "chore(${TYPE}): ${COMMIT_VERB} ${APP_NAME} v${VERSION}"
-git push -u origin "$BRANCH"
+echo "::group::Push to tap"
+BRANCH="brew-releaser/${APP_LOWER}-${VERSION}"
+ENCODED_CONTENT=$(echo "$NEW_CONTENT" | base64 | tr -d '\n')
+COMMIT_MSG="chore(${TYPE}): ${COMMIT_VERB} ${APP_NAME} v${VERSION}"
+
+gh_api POST "/repos/${TAP_REPO}/git/refs" \
+  -d "$(jq -n --arg ref "refs/heads/${BRANCH}" --arg sha "$MAIN_SHA" \
+    '{ref: $ref, sha: $sha}')" > /dev/null
+
+if [ -n "$EXISTING_SHA" ]; then
+  gh_api PUT "/repos/${TAP_REPO}/contents/${FILE_PATH}" \
+    -d "$(jq -n \
+      --arg message "$COMMIT_MSG" \
+      --arg content "$ENCODED_CONTENT" \
+      --arg sha "$EXISTING_SHA" \
+      --arg branch "$BRANCH" \
+      '{message: $message, content: $content, sha: $sha, branch: $branch}')" > /dev/null
+else
+  gh_api PUT "/repos/${TAP_REPO}/contents/${FILE_PATH}" \
+    -d "$(jq -n \
+      --arg message "$COMMIT_MSG" \
+      --arg content "$ENCODED_CONTENT" \
+      --arg branch "$BRANCH" \
+      '{message: $message, content: $content, branch: $branch}')" > /dev/null
+fi
+echo "  Pushed $FILE_PATH to $BRANCH"
+echo "::endgroup::"
 
 # --- Create PR ---
 
-BODY="Automated by [brew-releaser](https://github.com/${TAP_REPO}/tree/main/actions/brew-releaser).\n\n"
-BODY+="| Field | Value |\n|---|---|\n"
-BODY+="| **Type** | \`${TYPE}\` |\n"
-BODY+="| **Version** | \`${VERSION}\` |\n"
+echo "::group::Create PR"
+BODY="Automated by [brew-releaser](https://github.com/${TAP_REPO}/tree/main/actions/brew-releaser).
+
+| Field | Value |
+|---|---|
+| **Type** | \`${TYPE}\` |
+| **Version** | \`${VERSION}\` |"
+
 for key in "${!SHAS[@]}"; do
   label=$(echo "$key" | tr '_' '-')
-  BODY+="| **SHA256 (${label})** | \`${SHAS[$key]}\` |\n"
+  BODY+=$'\n'"| **SHA256 (${label})** | \`${SHAS[$key]}\` |"
 done
 
-RESPONSE=$(curl -fsSL -X POST \
-  -H "Authorization: token ${TOKEN}" \
-  -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/${TAP_REPO}/pulls" \
+RESPONSE=$(gh_api POST "/repos/${TAP_REPO}/pulls" \
   -d "$(jq -n \
     --arg title "chore(${TYPE}): ${APP_NAME} v${VERSION}" \
     --arg body "$BODY" \
@@ -290,3 +339,4 @@ RESPONSE=$(curl -fsSL -X POST \
 PR_URL=$(echo "$RESPONSE" | jq -r '.html_url // empty')
 echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 echo "Pull request: $PR_URL"
+echo "::endgroup::"

--- a/actions/brew-releaser/entrypoint.sh
+++ b/actions/brew-releaser/entrypoint.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Helpers ---
+
+hash_file() {
+  if command -v sha256sum &>/dev/null; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+download() {
+  local url="$1" dest="$2"
+  echo "  Downloading: $url"
+  curl -fSL --retry 3 --retry-delay 5 -o "$dest" "$url"
+}
+
+die() { echo "::error::$1"; exit 1; }
+
+# --- Resolve inputs ---
+
+TYPE="$INPUT_TYPE"
+VERSION="$INPUT_VERSION"
+APP_NAME="$INPUT_APP_NAME"
+TOKEN="$INPUT_TOKEN"
+TAP_REPO="$INPUT_TAP_REPO"
+APP_LOWER="${APP_NAME,,}"
+TAP_OWNER="${TAP_REPO%%/*}"
+HOMEPAGE="${INPUT_HOMEPAGE:-https://github.com/${TAP_OWNER}/${APP_NAME}}"
+DESC="${INPUT_DESC:-${APP_NAME}}"
+BIN="${INPUT_BINARY_NAME:-${APP_LOWER}}"
+BUNDLE_ID="com.${TAP_OWNER}.${APP_LOWER}"
+WORKDIR=$(mktemp -d /tmp/brew-releaser-XXXXXX)
+
+[[ "$TYPE" == "cask" || "$TYPE" == "formula" ]] || die "type must be 'cask' or 'formula', got '$TYPE'"
+[[ "$TYPE" == "cask" && -z "$INPUT_DMG_URL" ]] && die "dmg_url is required for type=cask"
+[[ "$TYPE" == "formula" && -z "$INPUT_FORMULA_URLS" ]] && die "formula_urls is required for type=formula"
+
+if [ -n "$INPUT_FILE_PATH" ]; then
+  FILE_PATH="$INPUT_FILE_PATH"
+elif [ "$TYPE" = "cask" ]; then
+  FILE_PATH="Casks/${APP_LOWER}.rb"
+else
+  FILE_PATH="Formula/${APP_LOWER}.rb"
+fi
+
+echo "file_path=$FILE_PATH" >> "$GITHUB_OUTPUT"
+
+# --- Download artifacts ---
+
+echo "::group::Download artifacts"
+declare -A SHAS
+
+if [ "$TYPE" = "cask" ]; then
+  download "$INPUT_DMG_URL" "$WORKDIR/arm64.dmg"
+  SHAS[arm64]=$(hash_file "$WORKDIR/arm64.dmg")
+  echo "  arm64 SHA256: ${SHAS[arm64]}"
+
+  if [ -n "$INPUT_DMG_X86_URL" ]; then
+    download "$INPUT_DMG_X86_URL" "$WORKDIR/x86_64.dmg"
+    SHAS[x86_64]=$(hash_file "$WORKDIR/x86_64.dmg")
+    echo "  x86_64 SHA256: ${SHAS[x86_64]}"
+  fi
+else
+  for key in $(echo "$INPUT_FORMULA_URLS" | jq -r 'keys[]'); do
+    safe=$(echo "$key" | tr '-' '_')
+    url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "$key" '.[$k]')
+    download "$url" "$WORKDIR/${safe}.tar.gz"
+    SHAS[$safe]=$(hash_file "$WORKDIR/${safe}.tar.gz")
+    echo "  $key SHA256: ${SHAS[$safe]}"
+  done
+fi
+echo "::endgroup::"
+
+# --- Clone tap ---
+
+echo "::group::Clone tap"
+git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/${TAP_REPO}.git" tap
+cd tap
+BRANCH="brew-releaser/${APP_LOWER}-${VERSION}"
+git checkout -b "$BRANCH"
+echo "::endgroup::"
+
+# --- Create or update file ---
+
+if [ -f "$FILE_PATH" ]; then
+  echo "::group::Update existing $TYPE"
+
+  sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$FILE_PATH"
+
+  if [ "$TYPE" = "cask" ]; then
+    if grep -q "on_arm" "$FILE_PATH"; then
+      sed -i "/on_arm/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHAS[arm64]}\"/;}" "$FILE_PATH"
+      if [ -n "${SHAS[x86_64]:-}" ]; then
+        sed -i "/on_intel/,/end/{s/sha256 \"[^\"]*\"/sha256 \"${SHAS[x86_64]}\"/;}" "$FILE_PATH"
+      fi
+    else
+      sed -i "s/sha256 \"[^\"]*\"/sha256 \"${SHAS[arm64]}\"/" "$FILE_PATH"
+    fi
+  else
+    update_formula_sha() {
+      local platform="$1" arch="$2"
+      local safe="${platform}_${arch}"
+      local sha="${SHAS[$safe]:-}"
+      [ -z "$sha" ] && return
+      local os_block
+      [ "$platform" = "darwin" ] && os_block="on_macos" || os_block="on_linux"
+      local cpu_check
+      [ "$arch" = "arm64" ] && cpu_check="arm?" || cpu_check="intel?"
+
+      local url
+      url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform}-${arch}" '.[$k] // empty')
+      [ -z "$url" ] && return
+
+      python3 - "$FILE_PATH" "$os_block" "$cpu_check" "$sha" "$url" <<'PYEOF'
+import sys, re
+path, os_block, cpu_check, sha, url = sys.argv[1:6]
+with open(path) as f:
+    content = f.read()
+pattern = rf'({os_block}\s+do.*?{re.escape(cpu_check)}.*?url\s+")[^"]*(".*?sha256\s+")[^"]*(")'
+def replacer(m):
+    return m.group(0)
+lines = content.split('\n')
+in_os = False
+in_cpu = False
+result = []
+for line in lines:
+    if os_block in line:
+        in_os = True
+    if in_os and cpu_check in line:
+        in_cpu = True
+    if in_cpu and 'url "' in line:
+        line = re.sub(r'url "[^"]*"', f'url "{url}"', line)
+    if in_cpu and 'sha256 "' in line:
+        line = re.sub(r'sha256 "[^"]*"', f'sha256 "{sha}"', line)
+        in_cpu = False
+    if in_os and line.strip() == 'end' and not in_cpu:
+        in_os = False
+    result.append(line)
+with open(path, 'w') as f:
+    f.write('\n'.join(result))
+PYEOF
+    }
+
+    for platform in darwin linux; do
+      for arch in arm64 x86_64; do
+        update_formula_sha "$platform" "$arch"
+      done
+    done
+  fi
+
+  echo "::endgroup::"
+  COMMIT_VERB="update"
+else
+  echo "::group::Create new $TYPE"
+  mkdir -p "$(dirname "$FILE_PATH")"
+  CASK_TOKEN=$(basename "$FILE_PATH" .rb)
+
+  if [ "$TYPE" = "cask" ]; then
+    {
+      echo "cask \"${CASK_TOKEN}\" do"
+      echo "  version \"${VERSION}\""
+
+      if [ -n "${SHAS[x86_64]:-}" ]; then
+        echo ""
+        echo "  on_arm do"
+        echo "    sha256 \"${SHAS[arm64]}\""
+        echo ""
+        echo "    url \"${INPUT_DMG_URL}\""
+        echo "  end"
+        echo "  on_intel do"
+        echo "    sha256 \"${SHAS[x86_64]}\""
+        echo ""
+        echo "    url \"${INPUT_DMG_X86_URL}\""
+        echo "  end"
+      else
+        echo "  sha256 \"${SHAS[arm64]}\""
+        echo ""
+        echo "  url \"${INPUT_DMG_URL}\""
+      fi
+
+      echo ""
+      echo "  name \"${APP_NAME}\""
+      echo "  desc \"${DESC}\""
+      echo "  homepage \"${HOMEPAGE}\""
+      echo ""
+      echo "  livecheck do"
+      echo "    url :url"
+      echo "    strategy :github_latest"
+      echo "  end"
+      echo ""
+      echo "  depends_on macos: \">= ${INPUT_MIN_MACOS}\""
+      echo ""
+      echo "  app \"${APP_NAME}.app\""
+      echo ""
+      echo "  postflight do"
+      echo "    system_command \"xattr\", args: [\"-cr\", \"#{appdir}/${APP_NAME}.app\"]"
+      echo "  end"
+      echo ""
+      echo "  zap trash: ["
+      echo "    \"~/.config/${APP_LOWER}\","
+      echo "    \"~/Library/Preferences/${BUNDLE_ID}.plist\","
+      echo "    \"~/Library/Saved Application State/${BUNDLE_ID}.savedState\","
+      echo "  ]"
+      echo "end"
+    } > "$FILE_PATH"
+  else
+    CLASS_NAME=$(echo "$CASK_TOKEN" | perl -pe 's/(^|[-_])(\w)/uc($2)/ge')
+    {
+      echo "class ${CLASS_NAME} < Formula"
+      echo "  desc \"${DESC}\""
+      echo "  homepage \"${HOMEPAGE}\""
+      echo "  version \"${VERSION}\""
+      [ -n "$INPUT_LICENSE" ] && echo "  license \"${INPUT_LICENSE}\""
+      echo ""
+
+      for os in macos linux; do
+        platform_key=$( [ "$os" = "macos" ] && echo "darwin" || echo "linux" )
+        arm_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-arm64" '.[$k] // empty')
+        x86_url=$(echo "$INPUT_FORMULA_URLS" | jq -r --arg k "${platform_key}-x86_64" '.[$k] // empty')
+        [ -z "$arm_url" ] && [ -z "$x86_url" ] && continue
+
+        echo "  on_${os} do"
+        if [ -n "$arm_url" ]; then
+          echo "    if Hardware::CPU.arm?"
+          echo "      url \"${arm_url}\""
+          echo "      sha256 \"${SHAS[${platform_key}_arm64]}\""
+        fi
+        if [ -n "$x86_url" ]; then
+          [ -n "$arm_url" ] && echo "    else" || echo "    if Hardware::CPU.intel?"
+          echo "      url \"${x86_url}\""
+          echo "      sha256 \"${SHAS[${platform_key}_x86_64]}\""
+        fi
+        echo "    end"
+        echo "  end"
+        echo ""
+      done
+
+      echo "  def install"
+      echo "    bin.install \"${BIN}\""
+      echo "  end"
+      echo ""
+      echo "  test do"
+      echo "    system \"#{bin}/${BIN}\", \"--version\""
+      echo "  end"
+      echo "end"
+    } > "$FILE_PATH"
+  fi
+
+  echo "::endgroup::"
+  COMMIT_VERB="add"
+fi
+
+echo "::group::Result"
+cat "$FILE_PATH"
+echo "::endgroup::"
+
+# --- Commit and push ---
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add "$FILE_PATH"
+git commit -m "chore(${TYPE}): ${COMMIT_VERB} ${APP_NAME} v${VERSION}"
+git push -u origin "$BRANCH"
+
+# --- Create PR ---
+
+BODY="Automated by [brew-releaser](https://github.com/${TAP_REPO}/tree/main/actions/brew-releaser).\n\n"
+BODY+="| Field | Value |\n|---|---|\n"
+BODY+="| **Type** | \`${TYPE}\` |\n"
+BODY+="| **Version** | \`${VERSION}\` |\n"
+for key in "${!SHAS[@]}"; do
+  label=$(echo "$key" | tr '_' '-')
+  BODY+="| **SHA256 (${label})** | \`${SHAS[$key]}\` |\n"
+done
+
+RESPONSE=$(curl -fsSL -X POST \
+  -H "Authorization: token ${TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${TAP_REPO}/pulls" \
+  -d "$(jq -n \
+    --arg title "chore(${TYPE}): ${APP_NAME} v${VERSION}" \
+    --arg body "$BODY" \
+    --arg head "$BRANCH" \
+    --arg base "main" \
+    '{title: $title, body: $body, head: $head, base: $base}')")
+
+PR_URL=$(echo "$RESPONSE" | jq -r '.html_url // empty')
+echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+echo "Pull request: $PR_URL"


### PR DESCRIPTION
### What's changed?

- Add `actions/brew-releaser/` — a composite GitHub Action that automates Homebrew Cask and Formula creation/updates
- Supports both Cask (macOS `.app` / DMG) and Formula (CLI binary / tar.gz)
- Auto-creates new Cask/Formula on first release; updates in-place on subsequent releases
- Downloads artifacts, computes SHA256, opens a PR to the tap automatically
- Upgrade `actions/checkout` from v4 to v6 across all existing workflows
- Add brew-releaser documentation to repo README

### Why

- No mature open-source tool exists for automating Homebrew Cask updates in third-party taps
- All 6+ Cask projects were duplicating ~80 lines of identical Makefile + workflow logic
- This action centralizes the tap update logic as a standard, versioned GitHub Action
- Ref: samzong/Mote#6