### PR TITLE
chore: update recall to 0.2.1

### DIFF
--- a/Formula/recall.rb
+++ b/Formula/recall.rb
@@ -1,21 +1,21 @@
 class Recall < Formula
   desc "Local-first TUI for searching AI coding session history"
   homepage "https://github.com/samzong/Recall"
-  version "0.1.5"
+  version "0.2.1"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/samzong/Recall/releases/download/v#{version}/recall-macos-aarch64.tar.gz"
-      sha256 "866cfb86f062f00ee14abf70137c7e905fbfa34c97e3de092966ff3bd8b117e0"
+      sha256 "d8a82eb1425c4f9057ef59a02583257fdd039051c588ab7e38506ffa9521f625"
     else
       url "https://github.com/samzong/Recall/releases/download/v#{version}/recall-macos-x86_64.tar.gz"
-      sha256 "8c81fcecdfb716ea69d549f9baefa5773ec691003c580b67f659e0450012e8d0"
+      sha256 "afff45676e4446d50a921509185f8c3c058634998248613937245c5b41b77a6d"
     end
   end
 
   on_linux do
     url "https://github.com/samzong/Recall/releases/download/v#{version}/recall-linux-x86_64.tar.gz"
-    sha256 "86b60e52dc26dab065d066db6f18df5df406f11704347bb1abb8ffc9e5eece2b"
+    sha256 "5fed98ad1a76e99125d1630f331ca10883a02b849a06c7b2c0fef0d9cf8015bd"
   end
 
   def install


### PR DESCRIPTION
## Summary
- update Recall formula from 0.1.5 to 0.2.1
- refresh SHA256 checksums for macOS arm64, macOS x86_64, and Linux x86_64 release assets

## Verification
- checked v0.2.1 release assets exist in samzong/Recall
- verified SHA256 checksums via `gh release download` + `shasum -a 256`
- ran `ruby -c Formula/recall.rb`

Note: `brew fetch --formula ./Formula/recall.rb --force` was attempted locally, but Homebrew rejected the standalone path because the cloned repo is not installed as a tap.