### PR TITLE
[Feat] Add manifest-driven package updater

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,6 +40,14 @@ jobs:
               pull_number: prNumber
             });
             
+            const headRef = pr.data.head.ref;
+            const headRepo = pr.data.head.repo.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (headRepo !== baseRepo || !/^update\/[A-Za-z0-9._-]+-[0-9]+/.test(headRef)) {
+              console.log(`Skipping PR #${prNumber}; only trusted update/* package branches are auto-merged. head=${headRepo}:${headRef}`);
+              return;
+            }
+
             // Check if PR is mergeable
             // mergeable can be null if GitHub hasn't computed mergeability yet
             const checkMergeabilityWithBackoff = async (retries, delay, maxDelay) => {

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,113 +2,70 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     paths:
       - 'Casks/**'
       - 'Formula/**'
+      - 'packages/manifest.yml'
+      - 'scripts/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  verify-sha256:
+  validate-package-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get changed files
-        id: changed-files
-        run: |
-          base=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-          files=$(git diff --name-only --diff-filter=ACMR "$base" ${{ github.event.pull_request.head.sha }} -- 'Formula/**' 'Casks/**' | tr '\n' ' ')
-          echo "all_changed_files=$files" >> "$GITHUB_OUTPUT"
+      - name: Validate manifest
+        run: ruby scripts/validate-manifest.rb
 
-      - name: Verify SHA256
-        if: steps.changed-files.outputs.all_changed_files != ''
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            if [[ $file == Formula/* ]] || [[ $file == Casks/* ]]; then
-              echo "Verifying SHA256 for $file"
-              while IFS= read -r line; do
-                if [[ $line =~ url[[:space:]]*\"([^\"]*)\" ]]; then
-                  url="${BASH_REMATCH[1]}"
-                  if [[ $url != *"#{version}"* && $url != *"#{arch}"* ]]; then
-                    echo "Checking URL: $url"
-                    actual_sha256=$(curl -sL "$url" | shasum -a 256 | cut -d ' ' -f 1)
-                    next_line=$(sed -n "$((NR+1))p" <<< "$(cat "$file")")
-                    if [[ $next_line =~ sha256[[:space:]]*\"([^\"]*)\" ]]; then
-                      declared_sha256="${BASH_REMATCH[1]}"
-                      if [[ "$actual_sha256" != "$declared_sha256" ]]; then
-                        echo "::error::SHA256 mismatch in $file"
-                        echo "::error::Declared: $declared_sha256"
-                        echo "::error::Actual: $actual_sha256"
-                        exit 1
-                      fi
-                    fi
-                  fi
-                fi
-              done < "$file"
-            fi
-          done
+      - name: Verify changed package files and checksums
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ruby scripts/review-package-pr.rb --base "$BASE_SHA" --head "$HEAD_SHA"
 
-  test-install:
-    needs: verify-sha256
+  brew-smoke-test:
+    needs: validate-package-pr
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get changed files
-        id: changed-files
+      - name: Get changed package files
+        id: changed
         run: |
-          base=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-          files=$(git diff --name-only --diff-filter=ACMR "$base" ${{ github.event.pull_request.head.sha }} -- 'Formula/**' 'Casks/**' | tr '\n' ' ')
-          echo "all_changed_files=$files" >> "$GITHUB_OUTPUT"
+          base=$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          files=$(git diff --name-only --diff-filter=ACMR "$base" "${{ github.event.pull_request.head.sha }}" -- 'Formula/**' 'Casks/**' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Homebrew
+      - name: Setup tap checkout
+        if: steps.changed.outputs.files != ''
         run: |
           brew update
-          brew tap samzong/tap https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
-          cd $(brew --repository samzong/tap)
-          git checkout ${{ github.event.pull_request.head.sha }}
+          brew tap samzong/tap "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          cd "$(brew --repository samzong/tap)"
+          git checkout "${{ github.event.pull_request.head.sha }}"
 
-      - name: Test installation
-        if: steps.changed-files.outputs.all_changed_files != ''
+      - name: Smoke test package installation
+        if: steps.changed.outputs.files != ''
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${{ steps.changed.outputs.files }}; do
             if [[ $file == Casks/* ]]; then
-              APP_NAME=$(basename "$file" .rb)
-              echo "Testing cask: $APP_NAME"
-              brew install --cask samzong/tap/$APP_NAME || {
-                echo "::error::Failed to install cask: $APP_NAME"
-                exit 1
-              }
+              token=$(basename "$file" .rb)
+              echo "Testing cask: $token"
+              brew install --cask --no-quarantine --force "samzong/tap/$token"
             elif [[ $file == Formula/* ]]; then
-              APP_NAME=$(basename "$file" .rb)
-              echo "Testing formula: $APP_NAME"
-              brew install samzong/tap/$APP_NAME || {
-                echo "::error::Failed to install formula: $APP_NAME"
-                exit 1
-              }
+              token=$(basename "$file" .rb)
+              echo "Testing formula: $token"
+              brew install "samzong/tap/$token"
+              brew test "samzong/tap/$token"
             fi
           done
-
-      - name: Add PR comment
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const outcome = '${{ job.status }}' === 'success' ? '✅' : '❌';
-            const body = `### Installation Test Result: ${outcome}
-
-            Test Environment: macOS Latest
-            Test Time: ${new Date().toISOString()}
-
-            ${outcome === '✅' ? 'All applications installed successfully!' : 'Installation test failed, please check the logs.'}`;
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });

--- a/.github/workflows/scan-outdated.yml
+++ b/.github/workflows/scan-outdated.yml
@@ -1,0 +1,72 @@
+name: Scan Outdated Packages
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      updates: ${{ steps.scan.outputs.updates }}
+      count: ${{ steps.scan.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate manifest
+        run: ruby scripts/validate-manifest.rb
+
+      - name: Scan packages
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: ruby scripts/scan-outdated.rb --report-file outdated-packages.md
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v4
+        with:
+          name: outdated-packages
+          path: outdated-packages.md
+
+  update:
+    needs: scan
+    if: needs.scan.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.scan.outputs.updates) }}
+    concurrency:
+      group: scheduled-update-${{ matrix.package }}-${{ matrix.version }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update package file
+        id: update
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          ruby scripts/update-package.rb \
+            --package "${{ matrix.package }}" \
+            --version "${{ matrix.version }}" \
+            --summary-file .update-package-summary.md
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          branch: ${{ steps.update.outputs.branch }}
+          delete-branch: true
+          commit-message: ${{ steps.update.outputs.title }}
+          title: ${{ steps.update.outputs.title }}
+          body-path: .update-package-summary.md

--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -1,0 +1,65 @@
+name: Update Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package name from packages/manifest.yml
+        required: true
+        type: string
+      version:
+        description: Release version, with or without v prefix. Defaults to latest published release.
+        required: false
+        default: latest
+        type: string
+  repository_dispatch:
+    types: [homebrew-package-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: update-package-${{ inputs.package || github.event.client_payload.package }}-${{ inputs.version || github.event.client_payload.version || 'latest' }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve input
+        id: input
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "package=${{ inputs.package }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version || 'latest' }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "package=${{ github.event.client_payload.package }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.event.client_payload.version || 'latest' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate manifest
+        run: ruby scripts/validate-manifest.rb
+
+      - name: Update package file
+        id: update
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          ruby scripts/update-package.rb \
+            --package "${{ steps.input.outputs.package }}" \
+            --version "${{ steps.input.outputs.version }}" \
+            --summary-file .update-package-summary.md
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          branch: ${{ steps.update.outputs.branch }}
+          delete-branch: true
+          commit-message: ${{ steps.update.outputs.title }}
+          title: ${{ steps.update.outputs.title }}
+          body-path: .update-package-summary.md

--- a/docs/usage/project-integration.md
+++ b/docs/usage/project-integration.md
@@ -1,0 +1,85 @@
+# Project Integration Guide
+
+This tap uses manifest-driven package updates.
+
+## Package ownership model
+
+- Source projects build and publish GitHub Release assets.
+- `samzong/homebrew-tap` owns Formula/Cask version and SHA256 updates.
+- The first `Formula/*.rb` or `Casks/*.rb` file is still created manually.
+- Automation only updates existing package files.
+
+## Default trigger: scheduled scan
+
+No source project changes are required for the default path.
+
+Every 30 minutes, `Scan Outdated Packages` reads `packages/manifest.yml`, compares each tap version to the latest non-draft GitHub release, and opens/updates a package PR when a package is stale and `auto_bump_on_scan` is enabled.
+
+## Optional fast path: release notification
+
+Projects that need immediate Homebrew updates can notify the tap after release assets are uploaded.
+
+Add this step at the end of the source repo release workflow:
+
+```yaml
+- name: Notify Homebrew tap
+  if: success()
+  env:
+    GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+  run: |
+    VERSION="${GITHUB_REF_NAME#v}"
+    gh api repos/samzong/homebrew-tap/dispatches \
+      --method POST \
+      --field event_type=homebrew-package-release \
+      --field client_payload[package]=PACKAGE_NAME \
+      --field client_payload[version]="${VERSION}"
+```
+
+Replace `PACKAGE_NAME` with the package key from `packages/manifest.yml`.
+
+The source project token only needs permission to trigger repository dispatch on `samzong/homebrew-tap`. It does not need to clone, push, or edit the tap.
+
+## Manual update
+
+Maintainers can run an update directly:
+
+```bash
+gh workflow run update-package.yml \
+  --repo samzong/homebrew-tap \
+  --field package=recall
+
+# Or pin a specific version:
+gh workflow run update-package.yml \
+  --repo samzong/homebrew-tap \
+  --field package=recall \
+  --field version=0.2.1
+```
+
+Local dry-run:
+
+```bash
+ruby scripts/update-package.rb \
+  --package recall \
+  --dry-run
+
+# Or pin a specific version:
+ruby scripts/update-package.rb \
+  --package recall \
+  --version 0.2.1 \
+  --dry-run
+```
+
+## Adding a new package
+
+1. Publish a GitHub release with stable asset names.
+2. Manually add the first `Formula/*.rb` or `Casks/*.rb` file.
+3. Add a package entry to `packages/manifest.yml`.
+4. Run:
+
+```bash
+ruby scripts/validate-manifest.rb
+ruby scripts/update-package.rb --package PACKAGE_NAME --dry-run
+```
+
+5. Trigger `Update Package` once manually.
+6. Optionally add the release notification step in the source project.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "update-readme": "node update-readme.js",
     "update": "node update-readme.js",
-    "test": "node update-readme.js --dry-run"
+    "test": "node update-readme.js --dry-run && ruby scripts/validate-manifest.rb",
+    "validate-manifest": "ruby scripts/validate-manifest.rb",
+    "scan-outdated": "ruby scripts/scan-outdated.rb",
+    "update-package": "ruby scripts/update-package.rb"
   },
   "keywords": ["homebrew", "automation", "readme"],
   "author": "samzong",

--- a/packages/manifest.yml
+++ b/packages/manifest.yml
@@ -1,0 +1,215 @@
+# Manifest-driven update rules for existing Homebrew Formula/Cask files.
+# The first .rb file for a package is still authored manually. This manifest only
+# tells the updater how to refresh version and SHA256 values for later releases.
+packages:
+  branchlight:
+    type: cask
+    source_repo: samzong/branchlight
+    path: Casks/branchlight.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: Branchlight-arm64.dmg
+        block: on_arm
+      x86_64:
+        filename: Branchlight-x86_64.dmg
+        block: on_intel
+
+  configforge:
+    type: cask
+    source_repo: samzong/ConfigForge
+    path: Casks/configforge.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: ConfigForge-arm64.dmg
+        block: on_arm
+      x86_64:
+        filename: ConfigForge-x86_64.dmg
+        block: on_intel
+
+  hf-model-downloader:
+    type: cask
+    source_repo: samzong/hf-model-downloader
+    path: Casks/hf-model-downloader.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: hf-model-downloader-arm64.dmg
+        block: on_arm
+      x86_64:
+        filename: hf-model-downloader-x86_64.dmg
+        block: on_intel
+
+  logo-wallpaper:
+    type: cask
+    source_repo: samzong/LogoWallpaper
+    path: Casks/logo-wallpaper.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: LogoWallpaper-arm64.dmg
+        block: on_arm
+      x86_64:
+        filename: LogoWallpaper-x86_64.dmg
+        block: on_intel
+
+  mac-music-player:
+    type: cask
+    source_repo: samzong/MacMusicPlayer
+    path: Casks/mac-music-player.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: MacMusicPlayer-arm64.dmg
+        block: on_arm
+      x86_64:
+        filename: MacMusicPlayer-x86_64.dmg
+        block: on_intel
+
+  prompts:
+    type: cask
+    source_repo: samzong/prompts
+    path: Casks/prompts.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: Prompts_{version}_aarch64.dmg
+        block: on_arm
+      x86_64:
+        filename: Prompts_{version}_x64.dmg
+        block: on_intel
+
+  saveeye:
+    type: cask
+    source_repo: samzong/SaveEye
+    path: Casks/saveeye.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: SaveEye-{version}-arm64.dmg
+        block: on_arm
+
+  gmc:
+    type: formula
+    source_repo: samzong/gmc
+    path: Formula/gmc.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      darwin_arm64:
+        filename: gmc_Darwin_arm64.tar.gz
+        url_match: gmc_Darwin_arm64.tar.gz
+      darwin_x86_64:
+        filename: gmc_Darwin_x86_64.tar.gz
+        url_match: gmc_Darwin_x86_64.tar.gz
+      linux_arm64:
+        filename: gmc_Linux_arm64.tar.gz
+        url_match: gmc_Linux_arm64.tar.gz
+      linux_x86_64:
+        filename: gmc_Linux_x86_64.tar.gz
+        url_match: gmc_Linux_x86_64.tar.gz
+
+  gofs:
+    type: formula
+    source_repo: samzong/gofs
+    path: Formula/gofs.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      darwin_x86_64:
+        filename: gofs_Darwin_x86_64.tar.gz
+        url_match: gofs_Darwin_x86_64.tar.gz
+      darwin_arm64:
+        filename: gofs_Darwin_arm64.tar.gz
+        url_match: gofs_Darwin_arm64.tar.gz
+      linux_x86_64:
+        filename: gofs_Linux_x86_64.tar.gz
+        url_match: gofs_Linux_x86_64.tar.gz
+      linux_arm64:
+        filename: gofs_Linux_arm64.tar.gz
+        url_match: gofs_Linux_arm64.tar.gz
+
+  mdctl:
+    type: formula
+    source_repo: samzong/mdctl
+    path: Formula/mdctl.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      darwin_arm64:
+        filename: mdctl_Darwin_arm64.tar.gz
+        url_match: mdctl_Darwin_arm64.tar.gz
+      darwin_x86_64:
+        filename: mdctl_Darwin_x86_64.tar.gz
+        url_match: mdctl_Darwin_x86_64.tar.gz
+      linux_arm64:
+        filename: mdctl_Linux_arm64.tar.gz
+        url_match: mdctl_Linux_arm64.tar.gz
+      linux_x86_64:
+        filename: mdctl_Linux_x86_64.tar.gz
+        url_match: mdctl_Linux_x86_64.tar.gz
+
+  mirrormate:
+    type: formula
+    source_repo: samzong/mirrormate
+    path: Formula/mirrormate.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      darwin_x86_64:
+        filename: mirrormate_Darwin_x86_64.tar.gz
+        url_match: mirrormate_Darwin_x86_64.tar.gz
+      darwin_arm64:
+        filename: mirrormate_Darwin_arm64.tar.gz
+        url_match: mirrormate_Darwin_arm64.tar.gz
+      linux_x86_64:
+        filename: mirrormate_Linux_x86_64.tar.gz
+        url_match: mirrormate_Linux_x86_64.tar.gz
+      linux_arm64:
+        filename: mirrormate_Linux_arm64.tar.gz
+        url_match: mirrormate_Linux_arm64.tar.gz
+
+  mm:
+    type: formula
+    source_repo: samzong/mm
+    path: Formula/mm.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      darwin_arm64:
+        filename: mm_Darwin_arm64.tar.gz
+        url_match: mm_Darwin_arm64.tar.gz
+      darwin_x86_64:
+        filename: mm_Darwin_x86_64.tar.gz
+        url_match: mm_Darwin_x86_64.tar.gz
+      linux_arm64:
+        filename: mm_Linux_arm64.tar.gz
+        url_match: mm_Linux_arm64.tar.gz
+      linux_x86_64:
+        filename: mm_Linux_x86_64.tar.gz
+        url_match: mm_Linux_x86_64.tar.gz
+
+  recall:
+    type: formula
+    source_repo: samzong/Recall
+    path: Formula/recall.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      macos_arm64:
+        filename: recall-macos-aarch64.tar.gz
+        url_match: recall-macos-aarch64.tar.gz
+      macos_x86_64:
+        filename: recall-macos-x86_64.tar.gz
+        url_match: recall-macos-x86_64.tar.gz
+      linux_x86_64:
+        filename: recall-linux-x86_64.tar.gz
+        url_match: recall-linux-x86_64.tar.gz

--- a/scripts/lib/homebrew_tap/package_tools.rb
+++ b/scripts/lib/homebrew_tap/package_tools.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "net/http"
+require "open-uri"
+require "pathname"
+require "tempfile"
+require "uri"
+require "yaml"
+
+module HomebrewTap
+  class Error < StandardError; end
+
+  module_function
+
+  def repo_root
+    Pathname.new(__dir__).join("../../..").expand_path
+  end
+
+  def normalize_version(version)
+    version.to_s.sub(/^v/, "")
+  end
+
+  def tag_for(package, version)
+    prefix = package.fetch("version_prefix", "v")
+    "#{prefix}#{normalize_version(version)}"
+  end
+
+  def expand_template(value, version:, tag:, filename: nil)
+    value.to_s
+         .gsub("{version}", version)
+         .gsub("{tag}", tag)
+         .gsub("{filename}", filename.to_s)
+  end
+
+  def sha256_file(path)
+    Digest::SHA256.file(path).hexdigest
+  end
+
+  def current_version(path)
+    content = File.read(path)
+    matches = content.scan(/^\s*version\s+"([^"]+)"/)
+    raise Error, "expected exactly one version line in #{path}, found #{matches.length}" unless matches.length == 1
+
+    normalize_version(matches[0][0])
+  end
+
+  class Manifest
+    attr_reader :path, :packages
+
+    def initialize(path)
+      @path = Pathname.new(path)
+      raw = YAML.safe_load(File.read(@path), aliases: false)
+      @packages = raw.fetch("packages")
+    rescue KeyError => e
+      raise Error, "invalid manifest #{path}: missing #{e.key}"
+    rescue Psych::Exception => e
+      raise Error, "invalid manifest #{path}: #{e.message}"
+    end
+
+    def package(name)
+      packages.fetch(name) { raise Error, "package not found in manifest: #{name}" }
+    end
+
+    def each_package(&block)
+      packages.each_pair(&block)
+    end
+
+    def package_for_path(path)
+      normalized = path.to_s
+      packages.find { |_name, package| package.fetch("path") == normalized }
+    end
+
+    def validate!(root: HomebrewTap.repo_root)
+      packages.each do |name, package|
+        validate_package!(name, package, root: root)
+      end
+    end
+
+    private
+
+    def validate_package!(name, package, root:)
+      %w[type source_repo path assets].each do |field|
+        raise Error, "#{name}: missing #{field}" unless package.key?(field)
+      end
+
+      type = package.fetch("type")
+      raise Error, "#{name}: type must be formula or cask" unless %w[formula cask].include?(type)
+
+      file = root.join(package.fetch("path"))
+      raise Error, "#{name}: package file does not exist: #{file}" unless file.file?
+
+      HomebrewTap.current_version(file)
+
+      assets = package.fetch("assets")
+      raise Error, "#{name}: assets must be a non-empty map" unless assets.is_a?(Hash) && assets.any?
+
+      filenames = assets.map do |asset_name, asset|
+        raise Error, "#{name}.#{asset_name}: missing filename" unless asset["filename"]
+
+        asset.fetch("filename")
+      end
+      duplicates = filenames.group_by(&:itself).select { |_filename, values| values.length > 1 }.keys
+      raise Error, "#{name}: duplicate asset filenames: #{duplicates.join(", ")}" if duplicates.any?
+    end
+  end
+
+  class GitHubClient
+    API = "https://api.github.com"
+
+    def initialize(token: ENV["GH_TOKEN"] || ENV["GITHUB_TOKEN"] || ENV["GH_PAT"])
+      @token = token.to_s.empty? ? nil : token
+    end
+
+    def release_by_tag(repo, tag)
+      request_json("/repos/#{repo}/releases/tags/#{URI.encode_www_form_component(tag)}")
+    end
+
+    def latest_release(repo, allow_prerelease: false)
+      releases = request_json("/repos/#{repo}/releases?per_page=30")
+      releases.find do |release|
+        !release.fetch("draft") && (allow_prerelease || !release.fetch("prerelease"))
+      end
+    end
+
+    def download(url, destination)
+      attempts = 0
+      begin
+        attempts += 1
+        download_once(url, destination)
+      rescue Error
+        raise
+      rescue StandardError => e
+        retry if attempts < 3
+
+        raise Error, "failed to download #{url}: #{e.class}: #{e.message}"
+      end
+    end
+
+    private
+
+    def download_once(url, destination)
+      uri = URI(url)
+      5.times do
+        request = Net::HTTP::Get.new(uri)
+        add_headers(request)
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+          response = http.request(request)
+          case response
+          when Net::HTTPSuccess
+            File.binwrite(destination, response.body)
+            return destination
+          when Net::HTTPRedirection
+            uri = URI(response.fetch("location"))
+            next
+          else
+            raise Error, "failed to download #{url}: HTTP #{response.code} #{response.message}"
+          end
+        end
+      end
+      raise Error, "too many redirects while downloading #{url}"
+    end
+
+    def request_json(path)
+      attempts = 0
+      begin
+        attempts += 1
+        uri = URI("#{API}#{path}")
+        request = Net::HTTP::Get.new(uri)
+        add_headers(request)
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+        raise Error, "GitHub API #{path} failed: HTTP #{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
+
+        JSON.parse(response.body)
+      rescue JSON::ParserError => e
+        raise Error, "GitHub API #{path} returned invalid JSON: #{e.message}"
+      rescue Error
+        raise
+      rescue StandardError => e
+        retry if attempts < 3
+
+        raise Error, "GitHub API #{path} failed: #{e.class}: #{e.message}"
+      end
+    end
+
+    def add_headers(request)
+      request["Accept"] = "application/vnd.github+json"
+      request["X-GitHub-Api-Version"] = "2022-11-28"
+      request["Authorization"] = "Bearer #{@token}" if @token
+      request["User-Agent"] = "samzong-homebrew-tap-updater"
+    end
+  end
+
+  class PackageEditor
+    attr_reader :path
+
+    def initialize(path)
+      @path = Pathname.new(path)
+      @lines = File.readlines(@path, chomp: true)
+    end
+
+    def content
+      @lines.join("\n") + "\n"
+    end
+
+    def write!
+      File.write(@path, content)
+    end
+
+    def replace_version!(version)
+      matches = @lines.each_index.select { |index| @lines[index] =~ /^\s*version\s+"[^"]+"/ }
+      raise Error, "expected exactly one version line in #{@path}, found #{matches.length}" unless matches.length == 1
+
+      index = matches.first
+      @lines[index] = @lines[index].sub(/version\s+"[^"]+"/, "version \"#{version}\"")
+    end
+
+    def update_asset!(asset, sha256:, url:)
+      if asset["block"]
+        update_asset_in_block!(asset.fetch("block"), asset, sha256: sha256, url: url)
+      else
+        update_asset_near_url!(asset, sha256: sha256, url: url)
+      end
+    end
+
+    def extract_sha(asset)
+      if asset["block"]
+        range = block_range(asset.fetch("block"))
+        sha_indexes = range.select { |index| @lines[index] =~ /sha256\s+"([0-9a-fA-F]{64})"/ }
+        raise Error, "#{@path}: expected exactly one sha256 in block #{asset.fetch("block")}, found #{sha_indexes.length}" unless sha_indexes.length == 1
+
+        @lines[sha_indexes.first].match(/sha256\s+"([0-9a-fA-F]{64})"/)[1].downcase
+      else
+        url_index = find_url_index(asset)
+        sha_index = find_following_sha_index(url_index)
+        @lines[sha_index].match(/sha256\s+"([0-9a-fA-F]{64})"/)[1].downcase
+      end
+    end
+
+    private
+
+    def update_asset_in_block!(block_name, asset, sha256:, url:)
+      range = block_range(block_name)
+      sha_indexes = range.select { |index| @lines[index] =~ /sha256\s+"[0-9a-fA-F]{64}"/ }
+      raise Error, "#{@path}: expected exactly one sha256 in block #{block_name}, found #{sha_indexes.length}" unless sha_indexes.length == 1
+
+      @lines[sha_indexes.first] = @lines[sha_indexes.first].sub(/sha256\s+"[0-9a-fA-F]{64}"/, "sha256 \"#{sha256}\"")
+
+      url_indexes = range.select { |index| @lines[index].include?("url \"") }
+      if url_indexes.length == 1 && should_update_url?(@lines[url_indexes.first], asset)
+        @lines[url_indexes.first] = replace_url_literal(@lines[url_indexes.first], url)
+      end
+    end
+
+    def update_asset_near_url!(asset, sha256:, url:)
+      url_index = find_url_index(asset)
+      @lines[url_index] = replace_url_literal(@lines[url_index], url) if should_update_url?(@lines[url_index], asset)
+
+      sha_index = find_following_sha_index(url_index)
+      @lines[sha_index] = @lines[sha_index].sub(/sha256\s+"[0-9a-fA-F]{64}"/, "sha256 \"#{sha256}\"")
+    end
+
+    def block_range(block_name)
+      start = nil
+      indent = nil
+      @lines.each_with_index do |line, index|
+        next unless line =~ /^(\s*)#{Regexp.escape(block_name)}\s+do\b/
+
+        start = index
+        indent = Regexp.last_match(1)
+        break
+      end
+      raise Error, "#{@path}: block not found: #{block_name}" unless start
+
+      finish = ((start + 1)...@lines.length).find { |index| @lines[index] =~ /^#{Regexp.escape(indent)}end\s*$/ }
+      raise Error, "#{@path}: block #{block_name} has no matching end" unless finish
+
+      (start..finish)
+    end
+
+    def find_url_index(asset)
+      patterns = [asset["url_match"], asset["filename"]].compact.map(&:to_s).reject(&:empty?)
+      matches = @lines.each_index.select do |index|
+        @lines[index].include?("url \"") && patterns.any? { |pattern| @lines[index].include?(pattern) }
+      end
+      raise Error, "#{@path}: expected exactly one url for #{patterns.join(" or ")}, found #{matches.length}" unless matches.length == 1
+
+      matches.first
+    end
+
+    def find_following_sha_index(url_index)
+      matches = []
+      ((url_index + 1)...@lines.length).each do |index|
+        break if @lines[index].include?("url \"")
+        break if @lines[index] =~ /^\s*end\s*$/
+
+        matches << index if @lines[index] =~ /sha256\s+"[0-9a-fA-F]{64}"/
+      end
+      raise Error, "#{@path}: expected exactly one sha256 after url on line #{url_index + 1}, found #{matches.length}" unless matches.length == 1
+
+      matches.first
+    end
+
+    def should_update_url?(line, asset)
+      asset["update_url"] == true || !line.include?('#{version}')
+    end
+
+    def replace_url_literal(line, url)
+      line.sub(/url\s+"[^"]+"/, "url \"#{url}\"")
+    end
+  end
+end

--- a/scripts/review-package-pr.rb
+++ b/scripts/review-package-pr.rb
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "open3"
+require_relative "lib/homebrew_tap/package_tools"
+
+options = {
+  manifest: "packages/manifest.yml",
+  root: HomebrewTap.repo_root,
+  base: ENV["BASE_SHA"],
+  head: ENV["HEAD_SHA"] || "HEAD"
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/review-package-pr.rb --base SHA --head SHA [options]"
+  parser.on("--manifest PATH", "Manifest path") { |value| options[:manifest] = value }
+  parser.on("--base SHA", "Base git revision") { |value| options[:base] = value }
+  parser.on("--head SHA", "Head git revision") { |value| options[:head] = value }
+end.parse!
+
+begin
+  raise HomebrewTap::Error, "--base is required" unless options[:base]
+
+  root = Pathname.new(options[:root])
+  manifest = HomebrewTap::Manifest.new(root.join(options[:manifest]))
+
+  diff_cmd = ["git", "diff", "--name-only", "--diff-filter=ACMR", options[:base], options[:head], "--", "Formula/**", "Casks/**"]
+  stdout, status = Open3.capture2(*diff_cmd, chdir: root.to_s)
+  raise HomebrewTap::Error, "failed to list changed package files" unless status.success?
+
+  changed = stdout.lines.map(&:strip).reject(&:empty?)
+  if changed.empty?
+    puts "No Formula/Cask changes to review."
+    exit 0
+  end
+
+  github = HomebrewTap::GitHubClient.new
+  failures = []
+
+  changed.each do |relative_path|
+    path = root.join(relative_path)
+    puts "Reviewing #{relative_path}"
+
+    system("ruby", "-c", path.to_s, exception: true)
+
+    package_name, package = manifest.package_for_path(relative_path)
+    unless package
+      puts "  #{relative_path} is not in manifest; ran syntax check only."
+      next
+    end
+
+    version = HomebrewTap.current_version(path)
+    tag = HomebrewTap.tag_for(package, version)
+    release = github.release_by_tag(package.fetch("source_repo"), tag)
+    if release.fetch("draft")
+      failures << "#{package_name}: release is draft: #{tag}"
+      next
+    end
+    if release.fetch("prerelease") && package["allow_prerelease"] != true
+      failures << "#{package_name}: release is prerelease but allow_prerelease is not enabled: #{tag}"
+      next
+    end
+
+    assets_by_name = release.fetch("assets").to_h { |asset| [asset.fetch("name"), asset] }
+    editor = HomebrewTap::PackageEditor.new(path)
+
+    package.fetch("assets").each do |asset_key, asset_config|
+      filename = HomebrewTap.expand_template(asset_config.fetch("filename"), version: version, tag: tag)
+      release_asset = assets_by_name[filename]
+      unless release_asset
+        failures << "#{package_name}.#{asset_key}: release asset missing: #{filename}"
+        next
+      end
+
+      Tempfile.create(["homebrew-tap-review", File.extname(filename)]) do |file|
+        github.download(release_asset.fetch("browser_download_url"), file.path)
+        actual = HomebrewTap.sha256_file(file.path)
+        declared = editor.extract_sha(asset_config.merge("filename" => filename))
+        if actual == declared
+          puts "  ok #{filename} #{actual}"
+        else
+          failures << "#{package_name}.#{asset_key}: SHA mismatch for #{filename}; declared #{declared}, actual #{actual}"
+        end
+      end
+    end
+  end
+
+  if failures.any?
+    warn "Package PR review failed:"
+    failures.each { |failure| warn "- #{failure}" }
+    exit 1
+  end
+
+  puts "Package PR review passed for #{changed.length} file(s)."
+rescue HomebrewTap::Error => e
+  warn "error: #{e.message}"
+  exit 1
+end

--- a/scripts/scan-outdated.rb
+++ b/scripts/scan-outdated.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "optparse"
+require_relative "lib/homebrew_tap/package_tools"
+
+options = {
+  manifest: "packages/manifest.yml",
+  root: HomebrewTap.repo_root,
+  include_report_only: false,
+  report_file: "outdated-packages.md"
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/scan-outdated.rb [options]"
+  parser.on("--manifest PATH", "Manifest path") { |value| options[:manifest] = value }
+  parser.on("--include-report-only", "Include packages with auto_bump_on_scan=false in the update matrix") do
+    options[:include_report_only] = true
+  end
+  parser.on("--report-file PATH", "Write markdown report") { |value| options[:report_file] = value }
+end.parse!
+
+begin
+  root = Pathname.new(options[:root])
+  manifest = HomebrewTap::Manifest.new(root.join(options[:manifest]))
+  github = HomebrewTap::GitHubClient.new
+  rows = []
+  updates = []
+
+  manifest.each_package do |name, package|
+    path = root.join(package.fetch("path"))
+    current = HomebrewTap.current_version(path)
+    auto = package.fetch("auto_bump_on_scan", true) != false
+
+    begin
+      latest = github.latest_release(package.fetch("source_repo"), allow_prerelease: package["allow_prerelease"] == true)
+    rescue HomebrewTap::Error => e
+      rows << [name, current, "n/a", "scan error: #{e.message}", auto ? "yes" : "no"]
+      next
+    end
+
+    if latest.nil?
+      rows << [name, current, "n/a", "no published release", auto ? "yes" : "no"]
+      next
+    end
+
+    latest_version = HomebrewTap.normalize_version(latest.fetch("tag_name"))
+    status = latest_version == current ? "current" : "outdated"
+    rows << [name, current, latest.fetch("tag_name"), status, auto ? "yes" : "no"]
+
+    next unless status == "outdated"
+    next unless auto || options[:include_report_only]
+
+    updates << { package: name, version: latest_version }
+  end
+
+  report = +"# Homebrew Tap Outdated Package Scan\n\n"
+  report << "| Package | Tap version | Latest release | Status | Auto bump on scan |\n"
+  report << "|---|---:|---:|---|---|\n"
+  rows.each do |name, current, latest, status, auto|
+    report << "| `#{name}` | `#{current}` | `#{latest}` | #{status} | #{auto} |\n"
+  end
+  report << "\nUpdate matrix candidates: `#{updates.length}`\n"
+
+  File.write(root.join(options[:report_file]), report)
+  File.open(ENV["GITHUB_STEP_SUMMARY"], "a") { |file| file.write(report) } if ENV["GITHUB_STEP_SUMMARY"]
+
+  if (output = ENV["GITHUB_OUTPUT"])
+    File.open(output, "a") do |file|
+      file.puts "updates=#{JSON.generate(updates)}"
+      file.puts "count=#{updates.length}"
+    end
+  end
+
+  puts report
+rescue HomebrewTap::Error => e
+  warn "error: #{e.message}"
+  exit 1
+end

--- a/scripts/update-package.rb
+++ b/scripts/update-package.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "optparse"
+require "tempfile"
+require_relative "lib/homebrew_tap/package_tools"
+
+options = {
+  manifest: "packages/manifest.yml",
+  root: HomebrewTap.repo_root,
+  dry_run: false,
+  summary_file: ".update-package-summary.md"
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/update-package.rb --package NAME [--version VERSION|latest] [options]"
+  parser.on("--package NAME", "Package name from packages/manifest.yml") { |value| options[:package] = value }
+  parser.on("--version VERSION", "Release version, with or without v prefix; defaults to latest") { |value| options[:version] = value }
+  parser.on("--manifest PATH", "Manifest path") { |value| options[:manifest] = value }
+  parser.on("--summary-file PATH", "Write PR summary markdown") { |value| options[:summary_file] = value }
+  parser.on("--dry-run", "Print the planned update without writing files") { options[:dry_run] = true }
+end.parse!
+
+tmpdir = nil
+
+begin
+  raise HomebrewTap::Error, "--package is required" unless options[:package]
+
+  root = Pathname.new(options[:root])
+  manifest = HomebrewTap::Manifest.new(root.join(options[:manifest]))
+  package = manifest.package(options[:package])
+  package_path = root.join(package.fetch("path"))
+
+  raise HomebrewTap::Error, "package file does not exist: #{package_path}; create it manually first" unless package_path.file?
+
+  github = HomebrewTap::GitHubClient.new
+  requested_version = options[:version].to_s.strip
+  if requested_version.empty? || requested_version == "latest"
+    release = github.latest_release(package.fetch("source_repo"), allow_prerelease: package["allow_prerelease"] == true)
+    raise HomebrewTap::Error, "no published release found for #{package.fetch("source_repo")}" unless release
+
+    tag = release.fetch("tag_name")
+    version = HomebrewTap.normalize_version(tag)
+  else
+    version = HomebrewTap.normalize_version(requested_version)
+    tag = HomebrewTap.tag_for(package, version)
+    release = github.release_by_tag(package.fetch("source_repo"), tag)
+    raise HomebrewTap::Error, "release is draft: #{package.fetch("source_repo")}@#{tag}" if release.fetch("draft")
+    if release.fetch("prerelease") && package["allow_prerelease"] != true
+      raise HomebrewTap::Error, "release is prerelease and allow_prerelease is not enabled: #{package.fetch("source_repo")}@#{tag}"
+    end
+  end
+
+  assets_by_name = release.fetch("assets").to_h { |asset| [asset.fetch("name"), asset] }
+  tmpdir = Dir.mktmpdir("homebrew-tap-update-")
+  computed_assets = []
+
+  package.fetch("assets").each do |asset_key, asset_config|
+    filename = HomebrewTap.expand_template(asset_config.fetch("filename"), version: version, tag: tag)
+    release_asset = assets_by_name[filename]
+    unless release_asset
+      available = assets_by_name.keys.sort.join(", ")
+      raise HomebrewTap::Error, "release asset not found for #{options[:package]}.#{asset_key}: #{filename}. Available: #{available}"
+    end
+
+    destination = File.join(tmpdir, filename)
+    github.download(release_asset.fetch("browser_download_url"), destination)
+    raise HomebrewTap::Error, "downloaded asset is empty: #{filename}" if File.zero?(destination)
+
+    sha256 = HomebrewTap.sha256_file(destination)
+    computed_assets << {
+      key: asset_key,
+      filename: filename,
+      url: release_asset.fetch("browser_download_url"),
+      sha256: sha256,
+      config: asset_config.merge("filename" => filename)
+    }
+  end
+
+  original = File.read(package_path)
+  editor = HomebrewTap::PackageEditor.new(package_path)
+  old_version = HomebrewTap.current_version(package_path)
+  editor.replace_version!(version)
+  computed_assets.each do |asset|
+    editor.update_asset!(asset.fetch(:config), sha256: asset.fetch(:sha256), url: asset.fetch(:url))
+  end
+  updated = editor.content
+
+  summary = +"## Summary\n"
+  summary << "- update `#{package.fetch("path")}` from `#{old_version}` to `#{version}`\n"
+  summary << "- source release: `#{package.fetch("source_repo")}@#{tag}`\n"
+  summary << "- refresh SHA256 checksums for configured release assets\n\n"
+  summary << "## Assets\n"
+  computed_assets.each do |asset|
+    summary << "- `#{asset.fetch(:filename)}`: `#{asset.fetch(:sha256)}`\n"
+  end
+  summary << "\n## Verification\n"
+  summary << "- verified GitHub release exists and is not draft\n"
+  summary << "- downloaded configured release assets and computed SHA256 values\n"
+  summary << "- updater changed only version/SHA256 and static URLs when required by the existing file format\n"
+
+  File.write(root.join(options[:summary_file]), summary)
+
+  if original == updated
+    puts "#{options[:package]} is already current at #{version}"
+  elsif options[:dry_run]
+    Tempfile.create(["homebrew-tap-update", ".rb"]) do |tmp|
+      tmp.write(updated)
+      tmp.flush
+      system("ruby", "-c", tmp.path, exception: true)
+      system("diff", "-u", package_path.to_s, tmp.path, exception: false)
+    end
+  else
+    File.write(package_path, updated)
+    system("ruby", "-c", package_path.to_s, exception: true)
+    puts "Updated #{package.fetch("path")} to #{version}"
+  end
+
+  if (output = ENV["GITHUB_OUTPUT"])
+    branch = "update/#{options[:package]}-#{version}"
+    title = "chore: update #{options[:package]} to #{version}"
+    File.open(output, "a") do |file|
+      file.puts "package=#{options[:package]}"
+      file.puts "version=#{version}"
+      file.puts "branch=#{branch}"
+      file.puts "title=#{title}"
+      file.puts "summary_file=#{options[:summary_file]}"
+    end
+  end
+rescue HomebrewTap::Error => e
+  warn "error: #{e.message}"
+  exit 1
+ensure
+  FileUtils.rm_rf(tmpdir) if tmpdir
+end

--- a/scripts/validate-manifest.rb
+++ b/scripts/validate-manifest.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require_relative "lib/homebrew_tap/package_tools"
+
+options = {
+  manifest: "packages/manifest.yml",
+  root: HomebrewTap.repo_root
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/validate-manifest.rb [--manifest PATH]"
+  parser.on("--manifest PATH", "Manifest path") { |value| options[:manifest] = value }
+end.parse!
+
+begin
+  root = Pathname.new(options[:root])
+  manifest = HomebrewTap::Manifest.new(root.join(options[:manifest]))
+  manifest.validate!(root: root)
+  puts "Manifest OK: #{manifest.packages.length} packages"
+rescue HomebrewTap::Error => e
+  warn "error: #{e.message}"
+  exit 1
+end


### PR DESCRIPTION
### What's changed?

- Add a manifest-driven package update system for existing Formula/Cask files.
- Add manual, repository-dispatch, and 30-minute scheduled update workflows.
- Add Ruby scripts for manifest validation, latest-release scanning, package updates, and PR checksum review.
- Harden package PR review and restrict auto-merge to trusted update branches.
- Document project integration and optional release notification.

### Why

- Centralizes Homebrew version/SHA update logic in the tap instead of copying update scripts across source projects.
- Keeps source project notifications optional while preserving timely updates through scheduled scanning.
