### PR TITLE
[Fix] Gate package auto-merge by eligibility label

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,6 +6,13 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
@@ -16,133 +23,199 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Get the related PR that triggered this workflow run
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const autoMergeLabel = 'auto-merge/package-update';
+            const eligibilityCheckName = 'Auto-merge eligibility';
+
             const workflowRun = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               run_id: ${{ github.event.workflow_run.id }}
             });
-            
-            // The PR Review workflow is triggered by a PR event, and from there, the PR number is found.
-            const prNumber = workflowRun.data.pull_requests[0]?.number;
-            
+
+            let prNumber = workflowRun.data.pull_requests[0]?.number;
+            if (!prNumber && workflowRun.data.head_branch) {
+              const prs = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${workflowRun.data.head_branch}`
+              });
+              prNumber = prs.data[0]?.number;
+            }
+
             if (!prNumber) {
               console.log('No PR associated with this workflow run.');
               return;
             }
-            
-            console.log(`Found PR #${prNumber}`);
-            
-            // Get PR details
+
             const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               pull_number: prNumber
             });
-            
-            const headRef = pr.data.head.ref;
-            const headRepo = pr.data.head.repo.full_name;
-            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            if (headRepo !== baseRepo || !/^update\/[A-Za-z0-9._-]+-[0-9]+/.test(headRef)) {
-              console.log(`Skipping PR #${prNumber}; only trusted update/* package branches are auto-merged. head=${headRepo}:${headRef}`);
+
+            const checkTime = check => Date.parse(check.completed_at || check.started_at || check.created_at || 0);
+            const latestCheckRunsForHead = async () => {
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: pr.data.head.sha,
+                per_page: 100
+              });
+              const latestByKey = new Map();
+              for (const check of checkRuns) {
+                const key = `${check.app?.slug || check.app?.id || 'unknown'}:${check.name}`;
+                const current = latestByKey.get(key);
+                if (!current || checkTime(check) > checkTime(current)) {
+                  latestByKey.set(key, check);
+                }
+              }
+              return [...latestByKey.values()];
+            };
+            const labelsForPr = async () => {
+              return github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100
+              });
+            };
+            const latestEligibilityCheck = checkRuns => checkRuns
+              .filter(check => check.name === eligibilityCheckName && check.app?.slug === 'github-actions')
+              .sort((left, right) => checkTime(right) - checkTime(left))[0];
+            const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+            const waitForEligibility = async () => {
+              for (let attempt = 1; attempt <= 12; attempt++) {
+                const [labels, latestCheckRuns] = await Promise.all([
+                  labelsForPr(),
+                  latestCheckRunsForHead()
+                ]);
+                const hasAutoMergeLabel = labels.some(label => label.name === autoMergeLabel);
+                const eligibilityCheck = latestEligibilityCheck(latestCheckRuns);
+
+                if (hasAutoMergeLabel && eligibilityCheck?.conclusion === 'success') {
+                  return { eligible: true, latestCheckRuns };
+                }
+
+                if (eligibilityCheck?.status === 'completed' && eligibilityCheck.conclusion && eligibilityCheck.conclusion !== 'success') {
+                  return {
+                    eligible: false,
+                    latestCheckRuns,
+                    reason: `${eligibilityCheckName} is ${eligibilityCheck.conclusion}`
+                  };
+                }
+
+                if (attempt < 12) {
+                  const checkState = eligibilityCheck
+                    ? `${eligibilityCheck.status}/${eligibilityCheck.conclusion || 'pending'}`
+                    : 'missing';
+                  console.log(`Waiting for ${autoMergeLabel} and ${eligibilityCheckName}: label=${hasAutoMergeLabel}, check=${checkState}`);
+                  await sleep(5000);
+                }
+              }
+
+              return {
+                eligible: false,
+                latestCheckRuns: await latestCheckRunsForHead(),
+                reason: `timed out waiting for ${autoMergeLabel} and ${eligibilityCheckName}`
+              };
+            };
+
+            const eligibility = await waitForEligibility();
+            if (!eligibility.eligible) {
+              console.log(`Skipping PR #${prNumber}: ${eligibility.reason}.`);
               return;
             }
+            const latestCheckRuns = eligibility.latestCheckRuns;
 
-            // Check if PR is mergeable
-            // mergeable can be null if GitHub hasn't computed mergeability yet
             const checkMergeabilityWithBackoff = async (retries, delay, maxDelay) => {
               for (let i = 0; i < retries; i++) {
                 if (pr.data.mergeable !== null) {
                   return pr.data.mergeable;
                 }
                 console.log(`PR #${prNumber} mergeability is still being computed. Waiting for ${delay}ms...`);
-                await new Promise(resolve => setTimeout(resolve, delay));
-                delay = Math.min(delay * 2, maxDelay); // Exponential backoff with upper limit
+                await sleep(delay);
+                delay = Math.min(delay * 2, maxDelay);
                 const updatedPr = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
+                  owner,
+                  repo,
                   pull_number: prNumber
                 });
                 pr.data.mergeable = updatedPr.data.mergeable;
               }
               return pr.data.mergeable;
             };
-            
-            const mergeable = await checkMergeabilityWithBackoff(5, 5000);
-            
+
+            const mergeable = await checkMergeabilityWithBackoff(5, 5000, 30000);
             if (mergeable === null || !mergeable) {
               console.log(`PR #${prNumber} is not mergeable after rechecking.`);
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 body: '⚠️ Automatic merge failed: This PR cannot be merged at the moment. Please resolve the conflicts and try again.'
               });
               return;
             }
-            
-            // Check if all checks have passed
-            const checks = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: pr.data.head.sha
-            });
-            
-            // Handle empty checks case - ensure we actually have some checks to verify
-            if (checks.data.check_runs.length === 0) {
+
+            if (latestCheckRuns.length === 0) {
               console.log(`PR #${prNumber} has no checks. Cannot verify status.`);
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 body: '⚠️ Automatic merge failed: No checks found for this PR. At least one check must run and pass before auto-merging.'
               });
               return;
             }
-            
-            const allChecksPass = checks.data.check_runs.every(check => 
-              check.conclusion === 'success' || check.conclusion === 'skipped'
+
+            const pendingChecks = latestCheckRuns.filter(check => check.status !== 'completed');
+            if (pendingChecks.length > 0) {
+              console.log(`Skipping PR #${prNumber}: checks still pending: ${pendingChecks.map(check => check.name).join(', ')}`);
+              return;
+            }
+
+            const failingChecks = latestCheckRuns.filter(check =>
+              check.conclusion !== 'success' && check.conclusion !== 'skipped'
             );
-            
-            if (!allChecksPass) {
-              console.log(`PR #${prNumber} has failed checks.`);
+            if (failingChecks.length > 0) {
+              console.log(`PR #${prNumber} has non-passing checks: ${failingChecks.map(check => `${check.name}=${check.conclusion}`).join(', ')}`);
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 body: '⚠️ Automatic merge failed: Some checks have failed. Please fix the failed checks.'
               });
               return;
             }
-            
-            // Perform the merge operation
+
             try {
               await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 pull_number: prNumber,
-                merge_method: 'merge'
+                sha: pr.data.head.sha,
+                merge_method: 'squash',
+                commit_title: pr.data.title
               });
-              
-              console.log(`Successfully merged PR #${prNumber}`);
-              
-              // Add a comment indicating successful merge
+
+              console.log(`Successfully squash-merged PR #${prNumber}`);
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
-                body: '🎉 Automatic merge successful: This PR has been automatically merged into the target branch.'
+                body: '🎉 Automatic merge successful: This PR has been automatically squash-merged into the target branch.'
               });
             } catch (error) {
               console.error(`Error merging PR #${prNumber}:`, error);
-              
-              // Add a comment indicating failed merge
-              // Ensure error.message is defined or use a fallback message
               const errorMessage = error.message || 'Automatic merge failed, no specific error information provided';
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 body: `❌ Automatic merge failed: ${errorMessage}`
               });
-            } 
+            }

--- a/.github/workflows/classify-pr.yml
+++ b/.github/workflows/classify-pr.yml
@@ -1,0 +1,193 @@
+name: Classify PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+permissions:
+  checks: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  classify-package-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Export package manifest
+        run: |
+          ruby -ryaml -rjson -e '
+            manifest = YAML.safe_load_file("packages/manifest.yml", aliases: false).fetch("packages")
+            packages = manifest.transform_values do |package|
+              {
+                path: package.fetch("path"),
+                auto_bump_on_scan: package["auto_bump_on_scan"] == true
+              }
+            end
+            File.write("package-manifest.json", JSON.generate(packages))
+          '
+
+      - name: Classify PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const packages = JSON.parse(fs.readFileSync('package-manifest.json', 'utf8'));
+            const autoMergeLabel = 'auto-merge/package-update';
+            const eligibilityCheckName = 'Auto-merge eligibility';
+            const reasons = [];
+
+            const baseRepo = `${owner}/${repo}`;
+            const headRepo = pr.head.repo?.full_name;
+            if (headRepo !== baseRepo) {
+              reasons.push(`head repository is ${headRepo}; expected ${baseRepo}`);
+            }
+
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            if (changedFiles.length !== 1) {
+              reasons.push(`changed file count is ${changedFiles.length}; expected 1`);
+            }
+
+            let packageName;
+            let packageConfig;
+            let previousVersion;
+            let nextVersion;
+            const changedFile = changedFiles[0];
+            if (changedFile) {
+              const manifestMatches = Object.entries(packages).filter(([, config]) => config.path === changedFile.filename);
+              if (manifestMatches.length !== 1) {
+                reasons.push(`${changedFile.filename} is not a package file managed by packages/manifest.yml`);
+              } else {
+                packageName = manifestMatches[0][0];
+                packageConfig = manifestMatches[0][1];
+              }
+
+              if (packageConfig && packageConfig.auto_bump_on_scan !== true) {
+                reasons.push(`${packageName} is not enabled for automatic package updates`);
+              }
+
+              if (changedFile.status !== 'modified') {
+                reasons.push(`changed file status is ${changedFile.status}; expected modified`);
+              }
+
+              const allowedPackageUpdateLine = content => {
+                return /^version\s+"[^"]+"$/.test(content) ||
+                  /^sha256\s+"[0-9a-fA-F]{64}"$/.test(content) ||
+                  /^url\s+"[^"]+"(?:,\s*.*)?$/.test(content);
+              };
+              const versionLine = content => content.match(/^version\s+"([^"]+)"$/)?.[1];
+
+              const changedPatchLines = (changedFile.patch || '')
+                .split('\n')
+                .filter(line => (line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---'));
+              const disallowedPatchLines = changedPatchLines.filter(line => !allowedPackageUpdateLine(line.slice(1).trim()));
+              const removedVersions = changedPatchLines
+                .filter(line => line.startsWith('-'))
+                .map(line => versionLine(line.slice(1).trim()))
+                .filter(Boolean);
+              const addedVersions = changedPatchLines
+                .filter(line => line.startsWith('+'))
+                .map(line => versionLine(line.slice(1).trim()))
+                .filter(Boolean);
+
+              if (!changedFile.patch) {
+                reasons.push('changed file patch is unavailable');
+              } else if (disallowedPatchLines.length > 0) {
+                reasons.push('package file edits include lines other than version, sha256, or url');
+              }
+
+              if (removedVersions.length !== 1 || addedVersions.length !== 1) {
+                reasons.push(`version change count is -${removedVersions.length}/+${addedVersions.length}; expected -1/+1`);
+              } else if (removedVersions[0] === addedVersions[0]) {
+                reasons.push(`version did not change: ${addedVersions[0]}`);
+              } else {
+                previousVersion = removedVersions[0];
+                nextVersion = addedVersions[0];
+              }
+            }
+
+            const eligible = reasons.length === 0;
+            const summary = eligible
+              ? `PR #${pr.number} updates ${packageName} from ${previousVersion} to ${nextVersion} and is eligible for automatic squash merge after required checks pass.`
+              : `PR #${pr.number} requires manual review:\n${reasons.map(reason => `- ${reason}`).join('\n')}`;
+
+            const ensureLabel = async () => {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: autoMergeLabel });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: autoMergeLabel,
+                    color: '0E8A16',
+                    description: 'Eligible for automatic package-update squash merge'
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                }
+              }
+            };
+
+            if (eligible) {
+              await ensureLabel();
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [autoMergeLabel]
+              });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: autoMergeLabel
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            if (headRepo === baseRepo) {
+              await github.rest.checks.create({
+                owner,
+                repo,
+                name: eligibilityCheckName,
+                head_sha: pr.head.sha,
+                status: 'completed',
+                conclusion: eligible ? 'success' : 'neutral',
+                output: {
+                  title: eligible ? 'Eligible for auto-merge' : 'Manual review required',
+                  summary
+                }
+              });
+            } else {
+              console.log('Skipping auto-merge eligibility check for fork PR head.');
+            }
+
+            console.log(summary);


### PR DESCRIPTION
### What's changed?

- Add a Classify PR workflow that labels same-repository manifest package version bumps as `auto-merge/package-update`.
- Require the current head SHA to have a successful `Auto-merge eligibility` check before auto-merging.
- Switch automatic merges to squash merges.

### Why

- Keep automatic merging limited to validated package update PRs.
- Leave all other PRs for human review.