### PR TITLE
[feat] Add Mailbell cask

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -137,7 +137,7 @@ jobs:
             if [[ $file == Casks/* ]]; then
               token=$(basename "$file" .rb)
               echo "Testing cask: $token"
-              brew install --cask --no-quarantine --force "samzong/tap/$token"
+              brew install --cask --force "samzong/tap/$token"
             elif [[ $file == Formula/* ]]; then
               token=$(basename "$file" .rb)
               echo "Testing formula: $token"

--- a/Casks/mailbell.rb
+++ b/Casks/mailbell.rb
@@ -1,0 +1,38 @@
+cask "mailbell" do
+  version "0.0.1"
+
+  on_arm do
+    sha256 "e4fd5791636b113c22125b4ed331f5b6a83e720026d7a8cb288192897f81270e"
+
+    url "https://github.com/samzong/mailbell/releases/download/v#{version}/Mailbell-arm64.dmg"
+  end
+
+  name "Mailbell"
+  desc "Menu bar Gmail notifier"
+  homepage "https://github.com/samzong/mailbell"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "Mailbell.app"
+
+  postflight do
+    system_command "xattr", args: ["-cr", "#{appdir}/Mailbell.app"]
+  end
+
+  zap trash: [
+    "/Library/Logs/DiagnosticReports/Mailbell*",
+    "~/Library/Application Support/Mailbell",
+    "~/Library/Caches/com.samzong.mailbell",
+    "~/Library/HTTPStorages/com.samzong.mailbell",
+    "~/Library/Logs/Mailbell",
+    "~/Library/Preferences/ByHost/com.samzong.mailbell.*.plist",
+    "~/Library/Preferences/com.samzong.mailbell.plist",
+    "~/Library/Saved Application State/com.samzong.mailbell.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ brew install mdctl
 
 | Application Name    | Type     | Description                                                                 | Latest Version |
 | ------------------- | -------- | --------------------------------------------------------------------------- | -------------- |
+| Mailbell | GUI App | Menu bar Gmail notifier | v0.0.1 |
 | Mote | GUI App | Menu bar app for rewriting selected text with OpenAI-compatible models | v0.1.0 |
 | mm | CLI Tool | CLI for that help you fast to contribution to projects | v0.0.6 |
 | recall | CLI Tool | Local-first TUI for searching AI coding session history | v0.2.2 |

--- a/packages/manifest.yml
+++ b/packages/manifest.yml
@@ -72,6 +72,17 @@ packages:
         filename: MacMusicPlayer-x86_64.dmg
         block: on_intel
 
+  mailbell:
+    type: cask
+    source_repo: samzong/mailbell
+    path: Casks/mailbell.rb
+    version_prefix: v
+    auto_bump_on_scan: true
+    assets:
+      arm64:
+        filename: Mailbell-arm64.dmg
+        block: on_arm
+
   mote:
     type: cask
     source_repo: samzong/mote


### PR DESCRIPTION
## Summary
- add the Mailbell cask for v0.0.1
- register Mailbell in the package manifest for future update automation
- refresh the README application table
- update the cask smoke test install command for current Homebrew

## Validation
- `make update-readme`
- `make test`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew style Casks/mailbell.rb`
- `git diff --check`
- verified release asset SHA256 with `curl -L ... | shasum -a 256`
